### PR TITLE
Fix module not found 'babel' for local development

### DIFF
--- a/examples/webpack.config.js
+++ b/examples/webpack.config.js
@@ -23,5 +23,8 @@ module.exports = {
   },
   plugins: [
     new webpack.HotModuleReplacementPlugin(),
-  ]
+  ],
+  resolveLoader: {
+    fallback: path.resolve(__dirname, 'node_modules'),
+  },
 }


### PR DESCRIPTION
Fix #17 

In examples folder, use `resolveLoader` to find `babel-loader` for local `connected-react-router` (for local development purpose)