### PR TITLE
Also allow ^5.0.0 react-redux peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "peerDependencies": {
     "react": "^15.0.0",
-    "react-redux": "^4.4.6",
+    "react-redux": "^4.4.6 || ^5.0.0",
     "redux": "^3.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
the latest stable version of react-redux is 5.0.2, which seems to work fine with this library to me.