### PR TITLE
Make time travelling optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "connected-react-router",
-  "version": "4.0.0-beta.3",
+  "version": "4.0.0-beta.4",
   "description": "A Redux binding for React Router v4",
   "main": "lib/index.js",
   "author": "Supasate Choochaisri",

--- a/src/ConnectedRouter.js
+++ b/src/ConnectedRouter.js
@@ -34,7 +34,7 @@ const createConnectedRouter = (structure) => {
         } = props.history.location
 
         // If we do time travelling, the location in store is changed but location in history is not changed
-        if (pathnameInHistory !== pathnameInStore || searchInHistory !== searchInStore || hashInHistory !== hashInStore) {
+        if (props.allowTimetravel && (pathnameInHistory !== pathnameInStore || searchInHistory !== searchInStore || hashInHistory !== hashInStore)) {
           this.inTimeTravelling = true
           // Update history's location to match store's location
           props.history.push({
@@ -93,6 +93,11 @@ const createConnectedRouter = (structure) => {
     basename: PropTypes.string,
     children: PropTypes.oneOfType([ PropTypes.func, PropTypes.node ]),
     onLocationChanged: PropTypes.func.isRequired,
+    allowTimetravel : PropTypes.bool.isRequired,
+  }
+
+  ConnectedRouter.defaultProps = {
+    allowTimetravel : true,
   }
 
   const mapStateToProps = state => ({


### PR DESCRIPTION
Hi,

in my specific case, I'm dispatching a `replace` action whenever no locale is set in the URL to go to a correct URL. E.g. `mysite.com` would be considered wrong because I want my URL to be `mysite.com/en-us` by default.

For some reason (because of the check for time travelling) the URL would always jump back to the previous one, the one without locale...

This PR adds an extra prop to `ConnectedRouter` to disable the time travelling. Default value is still true, so I believe this could be merged without any issues.

Usage:
```js
    <ConnectedRouter allowTimetravel={false}>
        ...
    </ConnectedRouter>
```