### PR TITLE
Add RouterState to typings

### DIFF
--- a/examples/typescript/src/reducers/index.ts
+++ b/examples/typescript/src/reducers/index.ts
@@ -1,4 +1,5 @@
 import { combineReducers } from 'redux'
+import { RouterState } from 'connected-react-router'
 import counterReducer from './counter'
 
 const rootReducer = combineReducers({
@@ -7,13 +8,7 @@ const rootReducer = combineReducers({
 
 export interface State {
   count: number
-  router: {
-    location: {
-      pathname: string
-      search: string
-      hash: string
-    }
-  }
+  router: RouterState
 }
 
 export default rootReducer

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,6 +7,16 @@ declare module 'connected-react-router' {
     history: History
   }
 
+  export interface RouterState {
+    location: {
+      pathname: string,
+      search: string,
+      hash: string,
+      key: string,
+    },
+    action: 'POP' | 'PUSH'
+  }
+
   export const LOCATION_CHANGE: string
   export const CALL_HISTORY_METHOD: string
 


### PR DESCRIPTION
This allows you to do e.g.:

```ts
interface State {
  count: number
  router: RouterState
}
```

instead of

```ts
interface State {
  count: number
  router: {
    location: {
      pathname: string
      search: string
      hash: string
    }
  }
}

```