### PR TITLE
Remove `lodash.topath` dependency to reduce bundle size.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   },
   "dependencies": {
     "immutable": "^3.8.1",
-    "lodash.topath": "^4.5.2",
     "react-router": "^4.1.0"
   },
   "peerDependencies": {

--- a/src/ConnectedRouter.js
+++ b/src/ConnectedRouter.js
@@ -26,7 +26,7 @@ const createConnectedRouter = (structure) => {
           pathname: pathnameInStore,
           search: searchInStore,
           hash: hashInStore,
-        } = toJS(getIn(context.store.getState(), 'router.location'))
+        } = toJS(getIn(context.store.getState(), ['router', 'location']))
         // Extract history's location
         const {
           pathname: pathnameInHistory,
@@ -97,8 +97,8 @@ const createConnectedRouter = (structure) => {
   }
 
   const mapStateToProps = state => ({
-    action: getIn(state, 'router.action'),
-    location: getIn(state, 'router.location'),
+    action: getIn(state, ['router', 'action']),
+    location: getIn(state, ['router', 'location']),
   })
 
   const mapDispatchToProps = dispatch => ({

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -31,12 +31,12 @@ const createConnectRouter = (structure) => {
 
       // Extract router state
       if (state) {
-        routerState = getIn(state, 'router') || routerState
+        routerState = getIn(state, ['router']) || routerState
         state = filterNotRouter(state)
       }
       const reducerResults = rootReducer(state, action)
 
-      return setIn(reducerResults, 'router', routerReducer(routerState, action))
+      return setIn(reducerResults, ['router'], routerReducer(routerState, action))
     }
   }
 

--- a/src/structure/immutable/getIn.js
+++ b/src/structure/immutable/getIn.js
@@ -1,11 +1,10 @@
 /* Code from github.com/erikras/redux-form by Erik Rasmussen */
 import { Iterable } from 'immutable'
-import toPath from 'lodash.topath'
 import plainGetIn from '../plain/getIn'
 
-const getIn = (state, field) =>
+const getIn = (state, path) =>
   Iterable.isIterable(state)
-    ? state.getIn(toPath(field))
-    : plainGetIn(state, field)
+    ? state.getIn(path)
+    : plainGetIn(state, path)
 
 export default getIn

--- a/src/structure/immutable/setIn.js
+++ b/src/structure/immutable/setIn.js
@@ -1,8 +1,5 @@
 /* Code from github.com/erikras/redux-form by Erik Rasmussen */
 import { List, Map } from 'immutable'
-import toPath from 'lodash.topath'
-
-const arrayPattern = /\[(\d+)\]/
 
 const undefinedArrayMerge = (previous, next) =>
   next !== undefined
@@ -23,12 +20,7 @@ const mergeLists = (original, value) =>
  * the setIn function uses `{}` to mark an unset value instead of
  * undefined (which is the case for list / arrays).
  */
-export default function setIn(state, field, value) {
-  const path = toPath(field)
-  if (!field || typeof field !== 'string' || !arrayPattern.test(field)) {
-    return state.setIn(path, value)
-  }
-
+export default function setIn(state, path, value) {
   return state.withMutations(mutable => {
     for (let pathIndex = 0; pathIndex < path.length - 1; ++pathIndex) {
       const nextPart = path[pathIndex + 1]

--- a/src/structure/plain/getIn.js
+++ b/src/structure/plain/getIn.js
@@ -1,12 +1,10 @@
 /* Code from github.com/erikras/redux-form by Erik Rasmussen */
-import toPath from 'lodash.topath'
 
-const getIn = (state, field) => {
+const getIn = (state, path) => {
   if (!state) {
     return state
   }
 
-  const path = toPath(field)
   const length = path.length
   if (!length) {
     return undefined

--- a/src/structure/plain/setIn.js
+++ b/src/structure/plain/setIn.js
@@ -1,5 +1,4 @@
 /* Code from github.com/erikras/redux-form by Erik Rasmussen */
-import toPath from 'lodash.topath'
 
 const setInWithPath = (state, value, path, pathIndex) => {
   if (pathIndex >= path.length) {
@@ -27,6 +26,6 @@ const setInWithPath = (state, value, path, pathIndex) => {
   }
 }
 
-const setIn = (state, field, value) => setInWithPath(state, value, toPath(field), 0)
+const setIn = (state, field, value) => setInWithPath(state, value, field, 0)
 
 export default setIn

--- a/yarn.lock
+++ b/yarn.lock
@@ -3015,10 +3015,6 @@ lodash.some@^4.4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.some/-/lodash.some-4.6.0.tgz#1bb9f314ef6b8baded13b549169b2a945eb68e4d"
 
-lodash.topath@^4.5.2:
-  version "4.5.2"
-  resolved "https://registry.yarnpkg.com/lodash.topath/-/lodash.topath-4.5.2.tgz#3616351f3bba61994a0931989660bd03254fd009"
-
 lodash@^4.0.0, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"


### PR DESCRIPTION
This PR removes `lodash.topath` from the dependencies.

Removing it decreased my minified bundle size by ~5kB. That's not too significant of a reduction - but every byte helps, and this change also simplifies the code a bit.

Thanks!