### PR TITLE
Update peerDependencies to include React 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "react-router": "^4.1.0"
   },
   "peerDependencies": {
-    "react": "^15.5.4",
+    "react": "^15.5.4 || ^16.0.0",
     "react-redux": "^4.4.8 || ^5.0.4",
     "redux": "^3.6.0"
   },


### PR DESCRIPTION
Fixes #59 by adding `^react@^16.0.0` to the peerDependencies. `connected-react-router` itself works fine with `react@^16`.