### PR TITLE
Add support for seamless-immutable structure

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
   },
   "dependencies": {
     "immutable": "^3.8.1",
-    "react-router": "^4.2.0"
+    "react-router": "^4.2.0",
+    "redux-seamless-immutable": "^0.4.0",
+    "seamless-immutable": "^7.1.3"
   },
   "peerDependencies": {
     "react": "^15.5.4 || ^16.0.0",

--- a/src/seamless-immutable.js
+++ b/src/seamless-immutable.js
@@ -1,0 +1,16 @@
+import createAll from './createAll'
+import immutableStructure from './structure/seamless-immutable'
+
+export const {
+  LOCATION_CHANGE,
+  CALL_HISTORY_METHOD,
+  push,
+  replace,
+  go,
+  goBack,
+  goForward,
+  routerActions,
+  ConnectedRouter,
+  connectRouter,
+  routerMiddleware,
+} = createAll(immutableStructure)

--- a/src/structure/seamless-immutable/index.js
+++ b/src/structure/seamless-immutable/index.js
@@ -1,0 +1,19 @@
+import SeamlessImmutable from 'seamless-immutable'
+import getIn from './../plain/getIn'
+import setIn from './../plain/setIn'
+
+const { static: Immutable } = SeamlessImmutable
+
+const structure = {
+  filterNotRouter: (state) => {
+    const { router, ...rest } = state // eslint-disable-line no-unused-vars
+    return rest
+  },
+  fromJS: value => Immutable.from(value),
+  getIn,
+  merge: (state, payload) => Immutable.merge(state, payload),
+  setIn,
+  toJS: value => Immutable.asMutable(value),
+}
+
+export default structure

--- a/test/ConnectedRouter.test.js
+++ b/test/ConnectedRouter.test.js
@@ -12,6 +12,7 @@ import createConnectedRouter from '../src/ConnectedRouter'
 import { onLocationChanged } from '../src/actions'
 import plainStructure from '../src/structure/plain'
 import immutableStructure from '../src/structure/immutable'
+import seamlessImmutableStructure from '../src/structure/seamless-immutable'
 import { connectRouter, ConnectedRouter } from '../src'
 
 Enzyme.configure({ adapter: new Adapter() })
@@ -115,6 +116,58 @@ describe('ConnectedRouter', () => {
 
     beforeEach(() => {
       ConnectedRouter = createConnectedRouter(immutableStructure)
+    })
+
+    it('calls `props.onLocationChanged()` when location changes.', () => {
+      mount(
+        <ContextWrapper store={store}>
+          <ConnectedRouter {...props}>
+            <Route path="/" render={() => <div>Home</div>} />
+          </ConnectedRouter>
+        </ContextWrapper>
+      )
+
+      expect(onLocationChangedSpy.mock.calls)
+        .toHaveLength(0)
+
+      history.push('/new-location')
+      history.push('/new-location-2')
+
+      expect(onLocationChangedSpy.mock.calls)
+        .toHaveLength(2)
+    })
+
+    it('unlistens the history object when unmounted.', () => {
+      const wrapper = mount(
+        <ContextWrapper store={store}>
+          <ConnectedRouter {...props}>
+            <Route path="/" render={() => <div>Home</div>} />
+          </ConnectedRouter>
+        </ContextWrapper>
+      )
+
+      expect(onLocationChangedSpy.mock.calls)
+        .toHaveLength(0)
+
+      history.push('/new-location')
+
+      expect(onLocationChangedSpy.mock.calls)
+        .toHaveLength(1)
+
+      wrapper.unmount()
+
+      history.push('/new-location-after-unmounted')
+
+      expect(onLocationChangedSpy.mock.calls)
+        .toHaveLength(1)
+    })
+  })
+
+  describe('with seamless immutable structure', () => {
+    let ConnectedRouter
+
+    beforeEach(() => {
+      ConnectedRouter = createConnectedRouter(seamlessImmutableStructure)
     })
 
     it('calls `props.onLocationChanged()` when location changes.', () => {

--- a/test/reducer.test.js
+++ b/test/reducer.test.js
@@ -1,8 +1,10 @@
 import { combineReducers } from 'redux'
 import { combineReducers as combineReducersImmutable } from 'redux-immutable'
+import { combineReducers as combineReducersSeamlessImmutable } from 'redux-seamless-immutable'
 import Immutable from 'immutable'
 import { LOCATION_CHANGE, connectRouter } from '../src'
-import { connectRouter as connectRouterImmutable} from '../src/immutable'
+import { connectRouter as connectRouterImmutable } from '../src/immutable'
+import { connectRouter as connectRouterSeamlessImmutable } from '../src/seamless-immutable'
 
 describe('connectRouter', () => {
   let mockHistory
@@ -114,6 +116,56 @@ describe('connectRouter', () => {
           action: 'PUSH',
         },
       })
+      expect(nextState).toEqual(expectedState)
+    })
+  })
+
+  describe('with seamless immutable structure', () => {
+    it('creates new root reducer with router reducer inside', () => {
+      const mockReducer = (state = {}, action) => {
+        switch (action.type) {
+          default:
+            return state
+        }
+      }
+      const rootReducer = combineReducersSeamlessImmutable({
+        mock: mockReducer,
+      })
+
+      const rootReducerWithRouter = connectRouterSeamlessImmutable(mockHistory)(rootReducer)
+      const currentState = {
+        router: {
+          location: {
+            pathname: '/',
+            search: '',
+            hash: '',
+          },
+          action: 'POP',
+        },
+      }
+      const action = {
+        type: LOCATION_CHANGE,
+        payload: {
+          location: {
+            pathname: '/path/to/somewhere',
+            search: '?query=test',
+            hash: '',
+          },
+          action: 'PUSH',
+        }
+      }
+      const nextState = rootReducerWithRouter(currentState, action)
+      const expectedState = {
+        mock: {},
+        router: {
+          location: {
+            pathname: '/path/to/somewhere',
+            search: '?query=test',
+            hash: '',
+          },
+          action: 'PUSH',
+        },
+      }
       expect(nextState).toEqual(expectedState)
     })
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -4200,6 +4200,10 @@ react-redux@^5.0.7:
     loose-envify "^1.1.0"
     prop-types "^15.6.0"
 
+react-router-redux@^4.0.0:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/react-router-redux/-/react-router-redux-4.0.8.tgz#227403596b5151e182377dab835b5d45f0f8054e"
+
 react-router@^4.2.0:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/react-router/-/react-router-4.3.1.tgz#aada4aef14c809cb2e686b05cee4742234506c4e"
@@ -4328,9 +4332,22 @@ redux-mock-store@^1.2.1:
   dependencies:
     lodash.isplainobject "^4.0.6"
 
+<<<<<<< HEAD
 redux@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.0.tgz#aa698a92b729315d22b34a0553d7e6533555cc03"
+=======
+redux-seamless-immutable@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/redux-seamless-immutable/-/redux-seamless-immutable-0.4.0.tgz#b50f8680ecc5ef04021551267f78fa1ffd3cf985"
+  dependencies:
+    react-router-redux "^4.0.0"
+    seamless-immutable "^7.1.2"
+
+redux@^3.6.0:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-3.7.2.tgz#06b73123215901d25d065be342eb026bc1c8537b"
+>>>>>>> Add support for seamless-immutable structure
   dependencies:
     loose-envify "^1.1.0"
     symbol-observable "^1.2.0"
@@ -4546,9 +4563,19 @@ sax@^1.2.1, sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
 
+<<<<<<< HEAD
 "semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.3.0, semver@^5.4.1:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
+=======
+seamless-immutable@^7.1.2, seamless-immutable@^7.1.3:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/seamless-immutable/-/seamless-immutable-7.1.3.tgz#d32a8a202a331dffa69e4069a367a2159252490e"
+
+"semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.3.0:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
+>>>>>>> Add support for seamless-immutable structure
 
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"


### PR DESCRIPTION
fixes #72 by adding a new structure in the structures folder. Reuses `getIn` and `setIn` of the plain structure