### PR TITLE
Update react-router version and set as peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,12 +24,12 @@
     "posttest": "npm run lint"
   },
   "dependencies": {
-    "immutable": "^3.8.1",
-    "react-router": "^4.2.0"
+    "immutable": "^3.8.1"
   },
   "peerDependencies": {
     "react": "^15.5.4 || ^16.0.0",
     "react-redux": "^4.4.8 || ^5.0.7",
+    "react-router": "^4.3.1",
     "redux": "^3.6.0 || ^4.0.0"
   },
   "devDependencies": {
@@ -51,12 +51,14 @@
     "eslint": "^3.12.0",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-react": "^6.8.0",
+    "history": "^4.7.2",
     "jest": "^17.0.2",
     "prop-types": "^15.5.8",
     "raf": "^3.4.0",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "react-redux": "^5.0.7",
+    "react-router": "^4.3.1",
     "react-test-renderer": "^16.0.0",
     "redux": "^4.0.0",
     "redux-devtools": "^3.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4074,11 +4074,18 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1:
+prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.6.0:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
   dependencies:
     fbjs "^0.8.16"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
+prop-types@^15.6.1:
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
+  dependencies:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
@@ -4200,7 +4207,7 @@ react-redux@^5.0.7:
     loose-envify "^1.1.0"
     prop-types "^15.6.0"
 
-react-router@^4.2.0:
+react-router@^4.3.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/react-router/-/react-router-4.3.1.tgz#aada4aef14c809cb2e686b05cee4742234506c4e"
   dependencies:


### PR DESCRIPTION
`react-router` should be treated as a peer dependency, so it's not bundled/required twice. Pretty much everyone using `connected-react-router` is also using `react-router`.