### PR TITLE
add RouterAction to typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 declare module 'connected-react-router' {
   import * as React from 'react'
-  import { Action, Middleware, Reducer } from 'redux'
+  import { Middleware, Reducer } from 'redux'
   import { History, Path, Location, LocationState, LocationDescriptorObject } from 'history'
 
   interface ConnectedRouterProps {
@@ -15,13 +15,13 @@ declare module 'connected-react-router' {
   export const LOCATION_CHANGE: string
   export const CALL_HISTORY_METHOD: string
 
-  export function push(path: Path, state?: LocationState): Action
-  export function push(location: LocationDescriptorObject): Action
-  export function replace(path: Path, state?: LocationState): Action
-  export function replace(location: LocationDescriptorObject): Action
-  export function go(n: number): Action
-  export function goBack(): Action
-  export function goForward(): Action
+  export function push(path: Path, state?: LocationState): RouterAction;
+  export function push(location: LocationDescriptorObject): RouterAction;
+  export function replace(path: Path, state?: LocationState): RouterAction;
+  export function replace(location: LocationDescriptorObject): RouterAction;
+  export function go(n: number): RouterAction
+  export function goBack(): RouterAction
+  export function goForward(): RouterAction
 
   export const routerActions: {
     push: typeof push,
@@ -29,6 +29,16 @@ declare module 'connected-react-router' {
     go: typeof go,
     goBack: typeof goBack,
     goForward: typeof goForward,
+  }
+
+  export interface LocationActionPayload {
+    method: string;
+    args?: any[];
+  }
+
+  export interface RouterAction {
+    type: typeof CALL_HISTORY_METHOD;
+    payload: LocationActionPayload;
   }
 
   export class ConnectedRouter extends React.Component<ConnectedRouterProps, {}> {


### PR DESCRIPTION
This adds the RouterAction type originally from @types/react-router-redux

It allows type-safe dispatching like this:

```typescript
const mapDispatchToProps = (dispatch: Dispatch<UsersAction | RouterAction>) => ({
  submit: (u: IUser) => {
    dispatch(actionCreators.updateUser(u));
    dispatch(push('/users'));
  }
});
```