### PR TITLE
dispatch location change action for initial location

### DIFF
--- a/src/ConnectedRouter.js
+++ b/src/ConnectedRouter.js
@@ -46,15 +46,19 @@ const createConnectedRouter = (structure) => {
         }
       })
 
-      // Listen to history changes
-      this.unlisten = props.history.listen((location, action) => {
+      const handleLocationChange = (location, action) => {
         // Dispatch onLocationChanged except when we're in time travelling
         if (!this.inTimeTravelling) {
           props.onLocationChanged(location, action)
         } else {
           this.inTimeTravelling = false
         }
-      })
+      }
+
+      // Listen to history changes
+      this.unlisten = props.history.listen(handleLocationChange)
+      // Dispatch a location change action for the initial location
+      handleLocationChange(props.history.location, props.history.action)
     }
 
     componentWillUnmount() {
@@ -82,6 +86,7 @@ const createConnectedRouter = (structure) => {
 
   ConnectedRouter.propTypes = {
     history: PropTypes.shape({
+      action: PropTypes.string.isRequired,
       listen: PropTypes.func.isRequired,
       location: PropTypes.object.isRequired,
       push: PropTypes.func.isRequired,

--- a/test/ConnectedRouter.test.js
+++ b/test/ConnectedRouter.test.js
@@ -75,13 +75,13 @@ describe('ConnectedRouter', () => {
       )
 
       expect(onLocationChangedSpy.mock.calls)
-        .toHaveLength(0)
+        .toHaveLength(1)
 
       history.push('/new-location')
       history.push('/new-location-2')
 
       expect(onLocationChangedSpy.mock.calls)
-        .toHaveLength(2)
+        .toHaveLength(3)
     })
 
     it('unlistens the history object when unmounted.', () => {
@@ -94,19 +94,19 @@ describe('ConnectedRouter', () => {
       )
 
       expect(onLocationChangedSpy.mock.calls)
-        .toHaveLength(0)
+        .toHaveLength(1)
 
       props.history.push('/new-location')
 
       expect(onLocationChangedSpy.mock.calls)
-        .toHaveLength(1)
+        .toHaveLength(2)
 
       wrapper.unmount()
 
       history.push('/new-location-after-unmounted')
 
       expect(onLocationChangedSpy.mock.calls)
-        .toHaveLength(1)
+        .toHaveLength(2)
     })
   })
 
@@ -127,13 +127,13 @@ describe('ConnectedRouter', () => {
       )
 
       expect(onLocationChangedSpy.mock.calls)
-        .toHaveLength(0)
+        .toHaveLength(1)
 
       history.push('/new-location')
       history.push('/new-location-2')
 
       expect(onLocationChangedSpy.mock.calls)
-        .toHaveLength(2)
+        .toHaveLength(3)
     })
 
     it('unlistens the history object when unmounted.', () => {
@@ -146,19 +146,19 @@ describe('ConnectedRouter', () => {
       )
 
       expect(onLocationChangedSpy.mock.calls)
-        .toHaveLength(0)
+        .toHaveLength(1)
 
       history.push('/new-location')
 
       expect(onLocationChangedSpy.mock.calls)
-        .toHaveLength(1)
+        .toHaveLength(2)
 
       wrapper.unmount()
 
       history.push('/new-location-after-unmounted')
 
       expect(onLocationChangedSpy.mock.calls)
-        .toHaveLength(1)
+        .toHaveLength(2)
     })
   })
 
@@ -218,7 +218,7 @@ describe('ConnectedRouter', () => {
 
       // When we toggle an action, the devtools will revert the action
       // and we therefore expect the history to update to the previous path
-      devToolsStore.dispatch(ActionCreators.toggleAction(2))
+      devToolsStore.dispatch(ActionCreators.toggleAction(3))
       expect(currentPath).toEqual('/foo2')
 
       historyUnsubscribe()


### PR DESCRIPTION
Dispatch a location change action for the initial location.

This allows code listening for the location change to be able to respond to the initial location in addition to subsequent location changes.