### PR TITLE
[FEAT]: Add selectors

### DIFF
--- a/src/createAll.js
+++ b/src/createAll.js
@@ -2,9 +2,11 @@ import * as actions from './actions'
 import createConnectedRouter from './ConnectedRouter'
 import createConnectRouter from './reducer'
 import routerMiddleware from './middleware'
+import createSelectors from './selectors'
 
 const createAll = structure => ({
   ...actions,
+  ...createSelectors(structure),
   ConnectedRouter: createConnectedRouter(structure),
   connectRouter: createConnectRouter(structure),
   routerMiddleware,

--- a/src/index.js
+++ b/src/index.js
@@ -13,4 +13,7 @@ export const {
   ConnectedRouter,
   connectRouter,
   routerMiddleware,
+  getLocation,
+  getAction,
+  createMatchSelector,
 } = createAll(plainStructure)

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -1,0 +1,33 @@
+import { matchPath } from "react-router"
+
+const createSelectors = (structure) => {
+  const { getIn, toJS } = structure
+  const getLocation = state => toJS(getIn(state, ['router', 'location']))
+  const getAction = state => toJS(getIn(state, ['router', 'action']))
+
+  // It only makes sense to recalculate the `matchPath` whenever the pathname
+  // of the location changes. That's why `createMatchSelector` memoizes
+  // the latest result based on the location's pathname.
+  const createMatchSelector = path => {
+    let lastPathname = null
+    let lastMatch = null
+
+    return state => {
+      const { pathname } = getLocation(state) || {}
+      if (pathname === lastPathname) {
+        return lastMatch
+      }
+      lastPathname = pathname
+      const match = matchPath(pathname, path)
+      if (!match || !lastMatch || match.url !== lastMatch.url) {
+        lastMatch = match
+      }
+
+      return lastMatch
+    }
+  }
+
+  return {getLocation, getAction, createMatchSelector}
+}
+
+export default createSelectors

--- a/test/selectors.test.js
+++ b/test/selectors.test.js
@@ -1,0 +1,109 @@
+import { createStore } from "redux"
+import { createBrowserHistory } from 'history'
+import { connectRouter, getLocation, createMatchSelector, getAction } from '../src'
+import { onLocationChanged } from '../src/actions'
+
+const push = pathname => onLocationChanged(
+  {
+    pathname,
+    search: '',
+    hash: '',
+  },
+  'PUSH'
+)
+
+describe("selectors", () => {
+  let store
+
+  beforeEach(() => {
+    const history = createBrowserHistory() 
+    const reducer = connectRouter(history)(() => {})
+    store = createStore(reducer)
+  })
+
+  describe("getLocation", () => {
+    it("gets the location from the state", () => {
+      const location = { pathname: "/", hash: '', search: '' }
+      store.dispatch(push('/'))
+      const state = store.getState()
+      expect(getLocation(state)).toEqual(location)
+    })
+  })
+
+  describe("getAction", () => {
+    it("gets the action from the state", () => {
+      const action = "PUSH"
+      store.dispatch(push('/'))
+      const state = store.getState()
+      expect(getAction(state)).toBe(action)
+    })
+  })
+
+  describe("createMatchSelector", () => {
+    it("matches correctly if the router is initialized", () => {
+      const matchSelector = createMatchSelector("/")
+      store.dispatch(push('/test'))
+      const state = store.getState()
+      expect(matchSelector(state)).toEqual({
+        isExact: false,
+        params: {},
+        path: "/",
+        url: "/"
+      })
+    })
+
+    it("does not throw error if router has not yet initialized", () => {
+      const matchSelector = createMatchSelector("/")
+      const state = store.getState()
+      expect(() => matchSelector(state)).not.toThrow()
+    })
+
+    it("does not update if the match is the same", () => {
+      const matchSelector = createMatchSelector("/")
+      store.dispatch(push('test1'))
+      const match = matchSelector(store.getState())
+      store.dispatch(push('test2'))
+      const expectedMatch = matchSelector(store.getState())
+      expect(match).toBe(expectedMatch)
+    })
+
+    it("updates if the match is different", () => {
+      const matchSelector = createMatchSelector("/sushi/:type")
+      store.dispatch(push('/sushi/california'))
+      const californiaMatch = matchSelector(store.getState())
+      store.dispatch(push('/sushi/dynamite'))
+      const dynamiteMatch = matchSelector(store.getState())
+      expect(californiaMatch).not.toBe(dynamiteMatch)
+      expect(californiaMatch).toEqual({
+        isExact: true,
+        params: {type: 'california'},
+        path: '/sushi/:type',
+        url: '/sushi/california',
+      })
+      expect(dynamiteMatch).toEqual({
+        isExact: true,
+        params: {type: 'dynamite'},
+        path: '/sushi/:type',
+        url: '/sushi/dynamite',
+      })
+    })
+
+    it("updates if the exact match is different", () => {
+      const matchSelector = createMatchSelector({
+        path: "/sushi",
+        exact: true
+      })
+      store.dispatch(push('/sushi'))
+      const okMatch = matchSelector(store.getState())
+      store.dispatch(push('/sushi/dynamite'))
+      const koMatch = matchSelector(store.getState())
+      expect(okMatch).toEqual({
+        isExact: true,
+        params: {},
+        path: '/sushi',
+        url: '/sushi',
+      })
+      expect(koMatch).toBe(null)
+    })
+  })
+})


### PR DESCRIPTION
Hi and thanks for this library!

I'm migrating from [react-router-redux](https://github.com/ReactTraining/react-router/tree/master/packages/react-router-redux) and the only thing that I'm really missing is its selectors... Specially the `createMatchSelector`. So, I have taken the ones from `react-router-redux` and I have migrated them (with their corresponding tests) so that they can work in this library.

I would really appreciate it if you could add them to `connected-react-router`.