### PR TITLE
Rename RouterAction(enum) to prevent exported name collision

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,14 +7,14 @@ declare module 'connected-react-router' {
     history: History
   }
   
-  export enum RouterAction {
+  export enum RouterActionType {
     POP = 'POP',
     PUSH = 'PUSH'
   }
 
   export interface RouterState {
     location: Location
-    action: RouterAction.POP | RouterAction.PUSH
+    action: RouterActionType.POP | RouterActionType.PUSH
   }
 
   export const LOCATION_CHANGE: string


### PR DESCRIPTION
<img width="718" alt="screen shot 2018-08-12 at 12 40 55" src="https://user-images.githubusercontent.com/5276065/44005760-a2d175ba-9e2d-11e8-90ad-b1b62e92d135.png">

There are two "export RouterAction" which caused this tslint error, we should export those with different names.