### PR TITLE
Expose routerReducer

### DIFF
--- a/src/createAll.js
+++ b/src/createAll.js
@@ -4,12 +4,16 @@ import createConnectRouter from './reducer'
 import routerMiddleware from './middleware'
 import createSelectors from './selectors'
 
-const createAll = structure => ({
+
+const createAll = structure => {
+  const {connectRouter, routerReducer} = createConnectRouter(structure)
+  return {
   ...actions,
   ...createSelectors(structure),
   ConnectedRouter: createConnectedRouter(structure),
-  connectRouter: createConnectRouter(structure),
+  connectRouter,
   routerMiddleware,
-})
+  routerReducer
+}}
 
 export default createAll

--- a/src/immutable.js
+++ b/src/immutable.js
@@ -13,4 +13,5 @@ export const {
   ConnectedRouter,
   connectRouter,
   routerMiddleware,
+  routerReducer
 } = createAll(immutableStructure)

--- a/src/index.js
+++ b/src/index.js
@@ -16,4 +16,5 @@ export const {
   getLocation,
   getAction,
   createMatchSelector,
+  routerReducer
 } = createAll(plainStructure)

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -40,7 +40,7 @@ const createConnectRouter = (structure) => {
     }
   }
 
-  return connectRouter
+  return {connectRouter, routerReducer}
 }
 
 export default createConnectRouter


### PR DESCRIPTION
Resolves #79.

Return an object containing `routerReducer` and `connectRouter` in `createConnectRouter` so that `routerReducer` can be exported.