### PR TITLE
getLocation, getAction, and createMatchSelector for immutable structures

### DIFF
--- a/src/immutable.js
+++ b/src/immutable.js
@@ -13,4 +13,7 @@ export const {
   ConnectedRouter,
   connectRouter,
   routerMiddleware,
+  getLocation,
+  getAction,
+  createMatchSelector,
 } = createAll(immutableStructure)

--- a/src/seamless-immutable.js
+++ b/src/seamless-immutable.js
@@ -12,5 +12,8 @@ export const {
   routerActions,
   ConnectedRouter,
   connectRouter,
-  routerMiddleware
+  routerMiddleware,
+  getLocation,
+  getAction,
+  createMatchSelector,
 } = createAll(immutableStructure)


### PR DESCRIPTION
those functions weren't exported in immutable and seamlessImmutable