### PR TITLE
Export routerReducer for custom root reducers (eg. redux-loop)

### DIFF
--- a/src/createAll.js
+++ b/src/createAll.js
@@ -1,6 +1,7 @@
 import * as actions from './actions'
 import createConnectedRouter from './ConnectedRouter'
-import createConnectRouter from './reducer'
+import createConnectRouter from './createConnectRouter'
+import createRouterReducer from './createRouterReducer'
 import routerMiddleware from './middleware'
 import createSelectors from './selectors'
 
@@ -9,6 +10,7 @@ const createAll = structure => ({
   ...createSelectors(structure),
   ConnectedRouter: createConnectedRouter(structure),
   connectRouter: createConnectRouter(structure),
+  routerReducer: createRouterReducer(structure),
   routerMiddleware,
 })
 

--- a/src/createConnectRouter.js
+++ b/src/createConnectRouter.js
@@ -1,30 +1,21 @@
-import { LOCATION_CHANGE } from './actions'
+import createRouterReducer from './createRouterReducer'
 
 const createConnectRouter = (structure) => {
   const {
     filterNotRouter,
     fromJS,
     getIn,
-    merge,
     setIn,
   } = structure
-  /**
-   * This reducer will update the state with the most recent location history
-   * has transitioned to.
-   */
-  const routerReducer = (state, { type, payload } = {}) => {
-    if (type === LOCATION_CHANGE) {
-      return merge(state, payload)
-    }
-
-    return state
-  }
 
   const connectRouter = (history) => {
     const initialRouterState = fromJS({
       location: history.location,
       action: history.action,
     })
+
+    const routerReducer = createRouterReducer(structure)(history)
+
     // Wrap a root reducer and return a new root reducer with router state
     return (rootReducer) => (state, action) => {
       let routerState = initialRouterState

--- a/src/createRouterReducer.js
+++ b/src/createRouterReducer.js
@@ -1,0 +1,33 @@
+import { LOCATION_CHANGE } from './actions'
+
+/**
+ * This reducer will update the state with the most recent location history
+ * has transitioned to.
+ */
+const createRouterReducer = (structure) => (history) =>  {
+  const {
+    fromJS,
+    merge,
+  } = structure
+
+  const initialState = fromJS({
+    location: history.location,
+    action: history.action,
+  })
+
+  /**
+   * This reducer will update the state with the most recent location history
+   * has transitioned to.
+   */
+  const routerReducer = (state = initialState, { type, payload } = {}) => {
+    if (type === LOCATION_CHANGE) {
+      return merge(state, payload)
+    }
+
+    return state
+  }
+
+  return routerReducer
+}
+
+export default createRouterReducer

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ export const {
   routerActions,
   ConnectedRouter,
   connectRouter,
+  routerReducer,
   routerMiddleware,
   getLocation,
   getAction,


### PR DESCRIPTION
Refactored `routerReducer` as a export of `connected-react-router` so that it can be used inside `redux-loop`'s `combineReducers` function.

### redux-loop example (with the new routerReducer export)

```javascript
import {
  install as installReduxLoop,
  combineReducers,
} from 'redux-loop'

import { createHashHistory } from 'history'
import { routerReducer, routerMiddleware } from 'connected-react-router'

const rootReducer = combineReducers({
  // ...your other reducers here
  router: routerReducer(history),
})

const enhancer = compose(
  applyMiddleware(
    routerMiddleware(history),
    // ... other middlewares ...
  ),
  installReduxLoop(),
)

const store = createStore(
  rootReducer,
  initialState,
  enhancer,
)
```

TL;DR: redux-loop support. All test pass. Previous functionality should not be effected.