### PR TITLE
Typescript: change RouterActionType from enum to simple union cause enum seems wrong

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,7 @@ declare module 'connected-react-router' {
     history: History
   }
   
-  export type RouterActionType = 'POP' | 'PUSH';
+  export type RouterActionType = 'POP' | 'PUSH' | 'REPLACE';
   
   export interface LocationChangeAction {
     type: typeof LOCATION_CHANGE;

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,11 +7,8 @@ declare module 'connected-react-router' {
     history: History
   }
   
-  export enum RouterActionType {
-    POP = 'POP',
-    PUSH = 'PUSH'
-  }
-
+  export type RouterActionType = 'POP' | 'PUSH';
+  
   export interface LocationChangeAction {
     type: typeof LOCATION_CHANGE;
     payload: RouterState;
@@ -19,7 +16,7 @@ declare module 'connected-react-router' {
 
   export interface RouterState {
     location: Location
-    action: RouterActionType.POP | RouterActionType.PUSH
+    action: RouterActionType
   }
 
   export const LOCATION_CHANGE: '@@router/LOCATION_CHANGE'


### PR DESCRIPTION
If I do:

`const action = RouterActionType.PUSH;`

I get:

> Uncaught TypeError: Cannot read property 'PUSH' of undefined

So from my point it seems that RouterActionType shound not be an enum and a simple union if PUSH and POP instead.

Additionally it seems REPLACE is missing in RouterActionType.