### PR TITLE
Use string literal type for CALL_HISTORY_METHOD

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -23,7 +23,7 @@ declare module 'connected-react-router' {
   }
 
   export const LOCATION_CHANGE: '@@router/LOCATION_CHANGE'
-  export const CALL_HISTORY_METHOD: string
+  export const CALL_HISTORY_METHOD: '@@router/CALL_HISTORY_METHOD'
 
   export function push(path: Path, state?: LocationState): RouterAction;
   export function push(location: LocationDescriptorObject): RouterAction;


### PR DESCRIPTION
Use the string literal `'@@router/CALL_HISTORY_METHOD'` as the type for `CALL_HISTORY_METHOD`.

I have a `type Action = LocationChangeAction | RouterAction` and would like to differentiate between types of actions using a switch statement like this:

```js
switch (action.type) {
case CALL_HISTORY_METHOD:
  // x
case LOCATION_CHANGE:
  // y
}
```

The type needs to be a string literal rather than a generic string type for this to work.