### PR TITLE
Updated action types.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,10 +1,16 @@
 declare module 'connected-react-router' {
-  import * as React from 'react'
-  import { Middleware, Reducer } from 'redux'
-  import { History, Path, Location, LocationState, LocationDescriptorObject } from 'history'
+  import * as React from 'react';
+  import { Middleware, Reducer } from 'redux';
+  import {
+    History,
+    Path,
+    Location,
+    LocationState,
+    LocationDescriptorObject
+  } from 'history';
 
   interface ConnectedRouterProps {
-    history: History
+    history: History;
   }
   
   export type RouterActionType = 'POP' | 'PUSH' | 'REPLACE';
@@ -19,41 +25,49 @@ declare module 'connected-react-router' {
     action: RouterActionType
   }
 
-  export const LOCATION_CHANGE: '@@router/LOCATION_CHANGE'
-  export const CALL_HISTORY_METHOD: '@@router/CALL_HISTORY_METHOD'
+  export const LOCATION_CHANGE: '@@router/LOCATION_CHANGE';
+  export const CALL_HISTORY_METHOD: '@@router/CALL_HISTORY_METHOD';
+
+  export interface LocationChangeAction {
+    type: typeof LOCATION_CHANGE;
+    payload: RouterState;
+  }
+
+  export interface CallHistoryMethodAction {
+    type: typeof CALL_HISTORY_METHOD;
+    payload: LocationActionPayload;
+  }
+
+  export type RouterAction = LocationChangeAction | CallHistoryMethodAction;
 
   export function push(path: Path, state?: LocationState): RouterAction;
   export function push(location: LocationDescriptorObject): RouterAction;
   export function replace(path: Path, state?: LocationState): RouterAction;
   export function replace(location: LocationDescriptorObject): RouterAction;
-  export function go(n: number): RouterAction
-  export function goBack(): RouterAction
-  export function goForward(): RouterAction
+  export function go(n: number): RouterAction;
+  export function goBack(): RouterAction;
+  export function goForward(): RouterAction;
 
   export const routerActions: {
-    push: typeof push,
-    replace: typeof replace,
-    go: typeof go,
-    goBack: typeof goBack,
-    goForward: typeof goForward,
-  }
+    push: typeof push;
+    replace: typeof replace;
+    go: typeof go;
+    goBack: typeof goBack;
+    goForward: typeof goForward;
+  };
 
   export interface LocationActionPayload {
     method: string;
     args?: any[];
   }
 
-  export interface RouterAction {
-    type: typeof CALL_HISTORY_METHOD;
-    payload: LocationActionPayload;
-  }
-
-  export class ConnectedRouter extends React.Component<ConnectedRouterProps, {}> {
-
-  }
+  export class ConnectedRouter extends React.Component<
+    ConnectedRouterProps,
+    {}
+  > {}
 
   export function connectRouter(history: History)
     : <S>(reducer: Reducer<S>) => Reducer<S & { router: RouterState }>
 
-  export function routerMiddleware(history: History): Middleware
+  export function routerMiddleware(history: History): Middleware;
 }


### PR DESCRIPTION
Before this, the `RouterAction` type was just typed to have a `string` type, which would cause errors in a typescript application by making the compiler think every action was a `RouterAction` I have changed these types to be strongly typed on the exact strings of those actions.