### PR TITLE
Fix FAQ anchor in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ See the [examples](https://github.com/supasate/connected-react-router/tree/maste
 [FAQ](https://github.com/supasate/connected-react-router/tree/master/FAQ.md)
 -----
 - [How to navigate with Redux action](https://github.com/supasate/connected-react-router/tree/master/FAQ.md#how-to-navigate-with-redux-action)
-- [How to get the current browser location (URL)](https://github.com/supasate/connected-react-router/tree/master/FAQ.md#how-to-get-current-browser-location-url)
+- [How to get the current browser location (URL)](https://github.com/supasate/connected-react-router/tree/master/FAQ.md#how-to-get-the-current-browser-location-url)
 - [How to set Router props e.g. basename, initialEntries, etc.](https://github.com/supasate/connected-react-router/tree/master/FAQ.md#how-to-set-router-props-eg-basename-initialentries-etc)
 - [How to hot reload functional components](https://github.com/supasate/connected-react-router/tree/master/FAQ.md#how-to-hot-reload-functional-components)
 - [How to hot reload reducers](https://github.com/supasate/connected-react-router/tree/master/FAQ.md#how-to-hot-reload-reducers)


### PR DESCRIPTION
The question "How to get the current browser location" points to a non-existing anchor.