### PR TITLE
Remove a duplicate LocationChangeAction interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -14,11 +14,6 @@ declare module 'connected-react-router' {
   }
   
   export type RouterActionType = 'POP' | 'PUSH' | 'REPLACE';
-  
-  export interface LocationChangeAction {
-    type: typeof LOCATION_CHANGE;
-    payload: RouterState;
-  }
 
   export interface RouterState {
     location: Location


### PR DESCRIPTION
I don't think it did any harm since it was merged with itself, but still.