### PR TITLE
Be more specific on action creators' return type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -40,13 +40,13 @@ declare module 'connected-react-router' {
 
   export type RouterAction = LocationChangeAction | CallHistoryMethodAction;
 
-  export function push(path: Path, state?: LocationState): RouterAction;
-  export function push(location: LocationDescriptorObject): RouterAction;
-  export function replace(path: Path, state?: LocationState): RouterAction;
-  export function replace(location: LocationDescriptorObject): RouterAction;
-  export function go(n: number): RouterAction;
-  export function goBack(): RouterAction;
-  export function goForward(): RouterAction;
+  export function push(path: Path, state?: LocationState): CallHistoryMethodAction;
+  export function push(location: LocationDescriptorObject): CallHistoryMethodAction;
+  export function replace(path: Path, state?: LocationState): CallHistoryMethodAction;
+  export function replace(location: LocationDescriptorObject): CallHistoryMethodAction;
+  export function go(n: number): CallHistoryMethodAction;
+  export function goBack(): CallHistoryMethodAction;
+  export function goForward(): CallHistoryMethodAction;
 
   export const routerActions: {
     push: typeof push;


### PR DESCRIPTION
Not sure if there was a reason for this, but all exposed action creators are known to return action with type `@@router/CALL_HISTORY_METHOD`, so the typings should reflect this, instead of being unambiguous about weather it's `@@router/LOCATION_CHANGE` or `@@router/CALL_HISTORY_METHOD`.