### PR TITLE
Fix package requirement name and grammar typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Main features
 
 Installation
 -----------
-Connected React Router requires **React 16.4 and Redux 6.0 or later**.
+Connected React Router requires **React 16.4 and React Redux 6.0 or later**.
 
 Using [npm](https://www.npmjs.com/):
 
@@ -42,7 +42,7 @@ Usage
 ### Step 1
 
 - Create a `history` object.
-- Create root reducer as a function that takes `history` as an argument and returns reducer.
+- Create a root reducer as a function that takes `history` as an argument and returns reducer.
 - Add `router` reducer into root reducer by passing `history` to `connectRouter`. Note: The key **MUST** be `router`.
 - Use `routerMiddleware(history)` if you want to dispatch history actions (e.g. to change URL with `push('/path/to/somewhere')`).
 


### PR DESCRIPTION
Since Redux is only on version 4, i presume that the requirement for the 6th version of this package must be `react-redux` :)