### PR TITLE
Prevent ConnectedRouter from re-rendering on every redux store update

### DIFF
--- a/src/ConnectedRouter.js
+++ b/src/ConnectedRouter.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import { connect, ReactReduxContext } from 'react-redux'
 import { Router } from 'react-router'
@@ -15,7 +15,7 @@ const createConnectedRouter = (structure) => {
    * This creates uni-directional flow from history->store->router->components.
    */
 
-  class ConnectedRouter extends Component {
+  class ConnectedRouter extends PureComponent {
     constructor(props) {
       super(props)
 


### PR DESCRIPTION
As discussed in #205 the children tree of `ConnectedRouter` component was re-rendering on every update from the redux store.

I tried out @jakewies`s example repository and think that the problem is with the shallow compare of props coming from Redux.

This PR replaces the plain `Component` from `ConnectedRouter` for a `PureComponent`, which includes shallow compare of props, and prevents re-renders if they're equal.