### PR TITLE
PoC: Fix double rendering

### DIFF
--- a/src/ConnectedRouter.js
+++ b/src/ConnectedRouter.js
@@ -6,8 +6,7 @@ import { onLocationChanged } from './actions'
 import createSelectors from './selectors'
 
 const createConnectedRouter = (structure) => {
-  const { getIn } = structure
-  const { getRouter, getLocation } = createSelectors(structure)
+  const { getLocation } = createSelectors(structure)
   /*
    * ConnectedRouter listens to a history object passed from props.
    * When history is changed, it dispatches action to redux store.
@@ -90,20 +89,10 @@ const createConnectedRouter = (structure) => {
       location: PropTypes.object.isRequired,
       push: PropTypes.func.isRequired,
     }).isRequired,
-    location: PropTypes.oneOfType([
-      PropTypes.object,
-      PropTypes.string,
-    ]).isRequired,
-    action: PropTypes.string.isRequired,
     basename: PropTypes.string,
     children: PropTypes.oneOfType([ PropTypes.func, PropTypes.node ]),
     onLocationChanged: PropTypes.func.isRequired,
   }
-
-  const mapStateToProps = state => ({
-    action: getIn(getRouter(state), ['action']),
-    location: getIn(getRouter(state), ['location']),
-  })
 
   const mapDispatchToProps = dispatch => ({
     onLocationChanged: (location, action) => dispatch(onLocationChanged(location, action))
@@ -127,7 +116,7 @@ const createConnectedRouter = (structure) => {
     context: PropTypes.object,
   }
 
-  return connect(mapStateToProps, mapDispatchToProps)(ConnectedRouterWithContext)
+  return connect(null, mapDispatchToProps)(ConnectedRouterWithContext)
 }
 
 export default createConnectedRouter

--- a/src/ConnectedRouter.js
+++ b/src/ConnectedRouter.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import { connect, ReactReduxContext } from 'react-redux'
 import { Router } from 'react-router'
@@ -15,7 +15,7 @@ const createConnectedRouter = (structure) => {
    * This creates uni-directional flow from history->store->router->components.
    */
 
-  class ConnectedRouter extends Component {
+  class ConnectedRouter extends PureComponent {
     constructor(props) {
       super(props)
 

--- a/test/ConnectedRouter.test.js
+++ b/test/ConnectedRouter.test.js
@@ -123,6 +123,25 @@ describe('ConnectedRouter', () => {
 
       expect(onLocationChangedSpy.mock.calls).toHaveLength(3)
     })
+
+    it('only renders once when mounted', () => {
+      let renderCount = 0
+
+      const RenderCounter = () => {
+        renderCount++
+        return null
+      }
+
+      mount(
+        <MockProvider store={store}>
+          <ConnectedRouter history={history}>
+              <Route path="/" render={() => <RenderCounter />} />
+          </ConnectedRouter>
+        </MockProvider>
+      )
+
+      expect(renderCount).toBe(1)
+    })
   })
 
   describe('with immutable structure', () => {

--- a/test/ConnectedRouter.test.js
+++ b/test/ConnectedRouter.test.js
@@ -134,7 +134,7 @@ describe('ConnectedRouter', () => {
 
       mount(
         <MockProvider store={store}>
-          <ConnectedRouter history={history}>
+          <ConnectedRouter {...props}>
               <Route path="/" component={RenderCounter} />
           </ConnectedRouter>
         </MockProvider>

--- a/test/ConnectedRouter.test.js
+++ b/test/ConnectedRouter.test.js
@@ -1,6 +1,5 @@
 import 'raf/polyfill'
-import React, { Children, Component } from 'react'
-import PropTypes from 'prop-types'
+import React from 'react'
 import configureStore from 'redux-mock-store'
 import { createStore, combineReducers, applyMiddleware, compose } from 'redux'
 import { ActionCreators, instrument } from 'redux-devtools'
@@ -8,7 +7,7 @@ import Enzyme from 'enzyme'
 import Adapter from 'enzyme-adapter-react-16'
 import { createMemoryHistory } from 'history'
 import { Route } from 'react-router'
-import { ReactReduxContext } from 'react-redux'
+import { Provider } from 'react-redux'
 import createConnectedRouter from '../src/ConnectedRouter'
 import { onLocationChanged } from '../src/actions'
 import plainStructure from '../src/structure/plain'
@@ -69,11 +68,11 @@ describe('ConnectedRouter', () => {
 
     it('calls `props.onLocationChanged()` when location changes.', () => {
       mount(
-        <MockProvider store={store}>
+        <Provider store={store}>
           <ConnectedRouter {...props}>
             <Route path="/" render={() => <div>Home</div>} />
           </ConnectedRouter>
-        </MockProvider>
+        </Provider>
       )
 
       expect(onLocationChangedSpy.mock.calls).toHaveLength(1)
@@ -86,11 +85,11 @@ describe('ConnectedRouter', () => {
 
     it('unlistens the history object when unmounted.', () => {
       const wrapper = mount(
-        <MockProvider store={store}>
+        <Provider store={store}>
           <ConnectedRouter {...props}>
             <Route path="/" render={() => <div>Home</div>} />
           </ConnectedRouter>
-        </MockProvider>
+        </Provider>
       )
 
       expect(onLocationChangedSpy.mock.calls).toHaveLength(1)
@@ -109,11 +108,11 @@ describe('ConnectedRouter', () => {
     it('supports custom context', () => {
       const context = React.createContext(null)
       mount(
-        <MockProvider store={store} context={context}>
+        <Provider store={store} context={context}>
           <ConnectedRouter {...props} context={context}>
             <Route path="/" render={() => <div>Home</div>} />
           </ConnectedRouter>
-        </MockProvider>
+        </Provider>
       )
 
       expect(onLocationChangedSpy.mock.calls).toHaveLength(1)
@@ -133,11 +132,11 @@ describe('ConnectedRouter', () => {
       }
 
       mount(
-        <MockProvider store={store}>
+        <Provider store={store}>
           <ConnectedRouter {...props}>
               <Route path="/" component={RenderCounter} />
           </ConnectedRouter>
-        </MockProvider>
+        </Provider>
       )
 
       expect(renderCount).toBe(1)
@@ -168,18 +167,18 @@ describe('ConnectedRouter', () => {
       }
 
       mount(
-        <MockProvider store={store}>
+        <Provider store={store}>
           <ConnectedRouter {...props}>
               <Route path="/" component={RenderCounter} />
           </ConnectedRouter>
-        </MockProvider>
+        </Provider>
       )
 
       store.dispatch({ type: 'testAction' })
       history.push('/new-location')
       expect(renderCount).toBe(2)
     })
-  }) 
+  })
 
   describe('with immutable structure', () => {
     let ConnectedRouter
@@ -190,11 +189,11 @@ describe('ConnectedRouter', () => {
 
     it('calls `props.onLocationChanged()` when location changes.', () => {
       mount(
-        <MockProvider store={store}>
+        <Provider store={store}>
           <ConnectedRouter {...props}>
             <Route path="/" render={() => <div>Home</div>} />
           </ConnectedRouter>
-        </MockProvider>
+        </Provider>
       )
 
       expect(onLocationChangedSpy.mock.calls).toHaveLength(1)
@@ -207,11 +206,11 @@ describe('ConnectedRouter', () => {
 
     it('unlistens the history object when unmounted.', () => {
       const wrapper = mount(
-        <MockProvider store={store}>
+        <Provider store={store}>
           <ConnectedRouter {...props}>
             <Route path="/" render={() => <div>Home</div>} />
           </ConnectedRouter>
-        </MockProvider>
+        </Provider>
       )
 
       expect(onLocationChangedSpy.mock.calls).toHaveLength(1)
@@ -230,11 +229,11 @@ describe('ConnectedRouter', () => {
     it('supports custom context', () => {
       const context = React.createContext(null)
       mount(
-        <MockProvider store={store} context={context}>
+        <Provider store={store} context={context}>
           <ConnectedRouter {...props} context={context}>
             <Route path="/" render={() => <div>Home</div>} />
           </ConnectedRouter>
-        </MockProvider>
+        </Provider>
       )
 
       expect(onLocationChangedSpy.mock.calls).toHaveLength(1)
@@ -243,6 +242,62 @@ describe('ConnectedRouter', () => {
       history.push('/new-location-2')
 
       expect(onLocationChangedSpy.mock.calls).toHaveLength(3)
+    })
+
+    it('only renders one time when mounted', () => {
+      let renderCount = 0
+
+      const RenderCounter = () => {
+        renderCount++
+        return null
+      }
+
+      mount(
+        <Provider store={store}>
+          <ConnectedRouter {...props}>
+              <Route path="/" component={RenderCounter} />
+          </ConnectedRouter>
+        </Provider>
+      )
+
+      expect(renderCount).toBe(1)
+    })
+
+    it('does not render again when non-related action is fired', () => {
+      // Initialize the render counter variable
+      let renderCount = 0
+
+      // Create redux store with router state
+      store = createStore(
+        combineReducers({
+          incrementReducer: (state = 0, action = {}) => {
+            if (action.type === 'testAction')
+              return ++state
+
+            return state
+          },
+          router: connectRouter(history)
+        }),
+        compose(applyMiddleware(routerMiddleware(history)))
+      )
+
+
+      const RenderCounter = () => {
+        renderCount++
+        return null
+      }
+
+      mount(
+        <Provider store={store}>
+          <ConnectedRouter {...props}>
+              <Route path="/" component={RenderCounter} />
+          </ConnectedRouter>
+        </Provider>
+      )
+
+      store.dispatch({ type: 'testAction' })
+      history.push('/new-location')
+      expect(renderCount).toBe(2)
     })
   })
 
@@ -255,11 +310,11 @@ describe('ConnectedRouter', () => {
 
     it('calls `props.onLocationChanged()` when location changes.', () => {
       mount(
-        <MockProvider store={store}>
+        <Provider store={store}>
           <ConnectedRouter {...props}>
             <Route path="/" render={() => <div>Home</div>} />
           </ConnectedRouter>
-        </MockProvider>
+        </Provider>
       )
 
       expect(onLocationChangedSpy.mock.calls).toHaveLength(1)
@@ -272,11 +327,11 @@ describe('ConnectedRouter', () => {
 
     it('unlistens the history object when unmounted.', () => {
       const wrapper = mount(
-        <MockProvider store={store}>
+        <Provider store={store}>
           <ConnectedRouter {...props}>
             <Route path="/" render={() => <div>Home</div>} />
           </ConnectedRouter>
-        </MockProvider>
+        </Provider>
       )
 
       expect(onLocationChangedSpy.mock.calls).toHaveLength(1)
@@ -290,6 +345,62 @@ describe('ConnectedRouter', () => {
       history.push('/new-location-after-unmounted')
 
       expect(onLocationChangedSpy.mock.calls).toHaveLength(2)
+    })
+
+    it('only renders one time when mounted', () => {
+      let renderCount = 0
+
+      const RenderCounter = () => {
+        renderCount++
+        return null
+      }
+
+      mount(
+        <Provider store={store}>
+          <ConnectedRouter {...props}>
+              <Route path="/" component={RenderCounter} />
+          </ConnectedRouter>
+        </Provider>
+      )
+
+      expect(renderCount).toBe(1)
+    })
+
+    it('does not render again when non-related action is fired', () => {
+      // Initialize the render counter variable
+      let renderCount = 0
+
+      // Create redux store with router state
+      store = createStore(
+        combineReducers({
+          incrementReducer: (state = 0, action = {}) => {
+            if (action.type === 'testAction')
+              return ++state
+
+            return state
+          },
+          router: connectRouter(history)
+        }),
+        compose(applyMiddleware(routerMiddleware(history)))
+      )
+
+
+      const RenderCounter = () => {
+        renderCount++
+        return null
+      }
+
+      mount(
+        <Provider store={store}>
+          <ConnectedRouter {...props}>
+              <Route path="/" component={RenderCounter} />
+          </ConnectedRouter>
+        </Provider>
+      )
+
+      store.dispatch({ type: 'testAction' })
+      history.push('/new-location')
+      expect(renderCount).toBe(2)
     })
   })
 
@@ -310,11 +421,11 @@ describe('ConnectedRouter', () => {
 
     it('resets to the initial url', () => {
       mount(
-        <MockProvider store={store}>
+        <Provider store={store}>
           <ConnectedRouter {...props}>
             <div>Test</div>
           </ConnectedRouter>
-        </MockProvider>
+        </Provider>
       )
 
       let currentPath
@@ -332,11 +443,11 @@ describe('ConnectedRouter', () => {
 
     it('handles toggle after history change', () => {
       mount(
-        <MockProvider store={store}>
+        <Provider store={store}>
           <ConnectedRouter {...props}>
             <div>Test</div>
           </ConnectedRouter>
-        </MockProvider>
+        </Provider>
       )
 
       let currentPath
@@ -356,36 +467,3 @@ describe('ConnectedRouter', () => {
     })
   })
 })
-
-// MockProvider mocks react-redux's Provider component
-class MockProvider extends Component {
-  constructor(props) {
-    super(props)
-    const { store } = props
-    this.state = {
-      storeState: store.getState(),
-      store,
-    }
-  }
-  render() {
-    const Context = this.props.context || ReactReduxContext
-
-    return (
-      <Context.Provider value={this.state}>
-        {Children.only(this.props.children)}
-      </Context.Provider>
-    )
-  }
-}
-
-const storeShape = PropTypes.shape({
-  subscribe: PropTypes.func.isRequired,
-  dispatch: PropTypes.func.isRequired,
-  getState: PropTypes.func.isRequired,
-})
-
-MockProvider.propTypes = {
-  context: PropTypes.object,
-  store: storeShape.isRequired,
-  children: PropTypes.element.isRequired,
-}


### PR DESCRIPTION
Based on #208 with some modifications
- Remove action and location props.
- Change test to use real Provider from react-redux instead of the mocked one.
- Test with plain, immutable, and seamless-immutable structures