### PR TITLE
Moving store and history subscription back to constructor

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "connected-react-router",
-  "version": "6.1.0",
+  "version": "6.2.0-beta.1",
   "description": "A Redux binding for React Router v4",
   "main": "lib/index.js",
   "module": "esm/index.js",

--- a/src/ConnectedRouter.js
+++ b/src/ConnectedRouter.js
@@ -15,8 +15,10 @@ const createConnectedRouter = (structure) => {
    */
 
   class ConnectedRouter extends PureComponent {
-    componentDidMount() {
-      const { store, history, onLocationChanged } = this.props
+    constructor(props) {
+      super(props)
+
+      const { store, history, onLocationChanged } = props
 
       this.inTimeTravelling = false
 
@@ -47,10 +49,10 @@ const createConnectedRouter = (structure) => {
         }
       })
 
-      const handleLocationChange = (location, action) => {
+      const handleLocationChange = (location, action, isFirstRendering = false) => {
         // Dispatch onLocationChanged except when we're in time travelling
         if (!this.inTimeTravelling) {
-          onLocationChanged(location, action)
+          onLocationChanged(location, action, isFirstRendering)
         } else {
           this.inTimeTravelling = false
         }


### PR DESCRIPTION
In #217, we move store and history subscription and the first `onLocationChange` call from `constructor` to `componentDidMount`. However, `react-router` subscribes `history` in `componentWillMount` (in 4.3.1) and `constructor` (in 4.4.0-beta). So, ConnectedRouter needs to subscribe to the store and history before `react-router`. 