### PR TITLE
Add missing typedef's for `getRouter` and `createMatchSelector`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,7 @@
 declare module 'connected-react-router' {
   import * as React from 'react';
   import { Middleware, Reducer } from 'redux';
+  import { match } from 'react-router';
   import {
     History,
     Path,
@@ -33,6 +34,14 @@ declare module 'connected-react-router' {
     payload: LocationActionPayload;
   }
 
+  export interface RouterRootState {
+    router: RouterState;
+  }
+
+  export type matchSelectorFn<
+    S extends RouterRootState, Params extends { [K in keyof Params]?: string }
+  > = (state: S) => match<Params> | null;
+
   export type RouterAction = LocationChangeAction | CallHistoryMethodAction;
 
   export function push(path: Path, state?: LocationState): CallHistoryMethodAction;
@@ -42,10 +51,14 @@ declare module 'connected-react-router' {
   export function go(n: number): CallHistoryMethodAction;
   export function goBack(): CallHistoryMethodAction;
   export function goForward(): CallHistoryMethodAction;
-  export function getAction(state: LocationState): RouterActionType;
-  export function getHash(state: LocationState): string;
-  export function getLocation(state: LocationState): Location;
-  export function getSearch(state: LocationState): string;
+  export function getRouter<S extends RouterRootState>(state: S): RouterState;
+  export function getAction<S extends RouterRootState>(state: S): RouterActionType;
+  export function getHash<S extends RouterRootState>(state: S): string;
+  export function getLocation<S extends RouterRootState>(state: S): Location;
+  export function getSearch<S extends RouterRootState>(state: S): string;
+  export function createMatchSelector<
+    S extends RouterRootState, Params extends { [K in keyof Params]?: string }
+  >(path: string): matchSelectorFn<S, Params>;
 
   export type Push = typeof push;
   export type Replace = typeof replace;

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@babel/preset-react": "^7.0.0",
     "@types/history": "^4.5.0",
     "@types/react": "*",
+    "@types/react-router": "^4.4.3",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "^10.0.1",
     "babel-jest": "^23.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -665,7 +665,7 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
-"@types/history@^4.5.0":
+"@types/history@*", "@types/history@^4.5.0":
   version "4.7.2"
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.2.tgz#0e670ea254d559241b6eeb3894f8754991e73220"
   integrity sha512-ui3WwXmjTaY73fOQ3/m3nnajU/Orhi6cEu5rzX+BrAAJxa3eITXZ5ch9suPqtM03OWhAHhPSyBGCN4UKoxO20Q==
@@ -679,6 +679,14 @@
   version "15.5.7"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.7.tgz#c6f1e0d0109ff358b132d98b7b4025c7a7b707c5"
   integrity sha512-a6WH0fXkgPNiGIuLjjdpf0n/GnmgWZ4vLuVIJJnDwhmRDPEaiRBcy5ofQPh+EJFua0S1QWmk1745+JqZQGnJ8Q==
+
+"@types/react-router@^4.4.3":
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/@types/react-router/-/react-router-4.4.3.tgz#ea68b4021cb576866f83365b2201411537423d50"
+  integrity sha512-8GmjakEBFNCLJbpg9jtDp1EDvFP0VkIPPKBpVwmB3Q+9whFoHu8rluMUXUE5SoGkEQvVOtgJzWmUsJojNpFMQQ==
+  dependencies:
+    "@types/history" "*"
+    "@types/react" "*"
 
 "@types/react@*":
   version "16.7.13"


### PR DESCRIPTION
- Add `@types/react-router` as devDependency
- Add typedef for root router state
- Add typedef for `getRouter`
- Add typedef for `createMatchSelector`
- Add typedef for router selectors to expect correct root state

Fixes #128 