### PR TITLE
Improving return types of action creators by adding generic args type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -29,7 +29,7 @@ declare module 'connected-react-router' {
     payload: RouterState;
   }
 
-  export interface CallHistoryMethodAction<A> {
+  export interface CallHistoryMethodAction<A = any[]> {
     type: typeof CALL_HISTORY_METHOD;
     payload: LocationActionPayload<A>;
   }
@@ -74,7 +74,7 @@ declare module 'connected-react-router' {
     goForward: GoForward;
   };
 
-  export interface LocationActionPayload<A> {
+  export interface LocationActionPayload<A = any[]> {
     method: string;
     args?: A;
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -29,9 +29,9 @@ declare module 'connected-react-router' {
     payload: RouterState;
   }
 
-  export interface CallHistoryMethodAction {
+  export interface CallHistoryMethodAction<A> {
     type: typeof CALL_HISTORY_METHOD;
-    payload: LocationActionPayload;
+    payload: LocationActionPayload<A>;
   }
 
   export interface RouterRootState {
@@ -44,13 +44,13 @@ declare module 'connected-react-router' {
 
   export type RouterAction = LocationChangeAction | CallHistoryMethodAction;
 
-  export function push(path: Path, state?: LocationState): CallHistoryMethodAction;
-  export function push(location: LocationDescriptorObject): CallHistoryMethodAction;
-  export function replace(path: Path, state?: LocationState): CallHistoryMethodAction;
-  export function replace(location: LocationDescriptorObject): CallHistoryMethodAction;
-  export function go(n: number): CallHistoryMethodAction;
-  export function goBack(): CallHistoryMethodAction;
-  export function goForward(): CallHistoryMethodAction;
+  export function push(path: Path, state?: LocationState): CallHistoryMethodAction<[ Path, LocationState? ]>;
+  export function push<S = LocationState>(location: LocationDescriptorObject<S>): CallHistoryMethodAction<[ LocationDescriptorObject<S> ]>;
+  export function replace(path: Path, state?: LocationState): CallHistoryMethodAction<[ Path, LocationState? ]>;
+  export function replace<S = LocationState>(location: LocationDescriptorObject<S>): CallHistoryMethodAction<[ LocationDescriptorObject<S> ]>;
+  export function go(n: number): CallHistoryMethodAction<[ number ]>;
+  export function goBack(): CallHistoryMethodAction<[]>;
+  export function goForward(): CallHistoryMethodAction<[]>;
   export function getRouter<S extends RouterRootState>(state: S): RouterState;
   export function getAction<S extends RouterRootState>(state: S): RouterActionType;
   export function getHash<S extends RouterRootState>(state: S): string;
@@ -74,9 +74,9 @@ declare module 'connected-react-router' {
     goForward: GoForward;
   };
 
-  export interface LocationActionPayload {
+  export interface LocationActionPayload<A> {
     method: string;
-    args?: any[];
+    args?: A;
   }
 
   export class ConnectedRouter extends React.Component<


### PR DESCRIPTION
The reason for this is to have better autocomplete on the created actions.
It seems like a very niche use, but I ran into it and would like to have better autocompletes.

Also improves the LocationState type inside LocationDescriptorObject, before it was aways `any`.