### PR TITLE
Add optional context prop type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,7 @@
 declare module 'connected-react-router' {
   import * as React from 'react';
   import { Middleware, Reducer } from 'redux';
+  import { ReactReduxContextValue } from 'react-redux';
   import { match } from 'react-router';
   import {
     History,
@@ -12,6 +13,7 @@ declare module 'connected-react-router' {
 
   interface ConnectedRouterProps {
     history: History;
+    context?: React.Context<ReactReduxContextValue>;
   }
 
   export type RouterActionType = 'POP' | 'PUSH' | 'REPLACE';

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@babel/preset-react": "^7.0.0",
     "@types/history": "^4.5.0",
     "@types/react": "*",
+    "@types/react-redux": "^7.0.0",
     "@types/react-router": "^4.4.3",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "^10.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -680,6 +680,14 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.7.tgz#c6f1e0d0109ff358b132d98b7b4025c7a7b707c5"
   integrity sha512-a6WH0fXkgPNiGIuLjjdpf0n/GnmgWZ4vLuVIJJnDwhmRDPEaiRBcy5ofQPh+EJFua0S1QWmk1745+JqZQGnJ8Q==
 
+"@types/react-redux@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.0.0.tgz#8aaba50fb43739462c40e65e85f96eb8a550d494"
+  integrity sha512-p5/vXqS4+Gq7EYzNv4SMi/yy7cM/BUbZORlPXY6F8wCyo5EfPa3Gpf6CEQX+UtbK5g2mqgERqVYyutzZYKIpaQ==
+  dependencies:
+    "@types/react" "*"
+    redux "^4.0.0"
+
 "@types/react-router@^4.4.3":
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/@types/react-router/-/react-router-4.4.3.tgz#ea68b4021cb576866f83365b2201411537423d50"


### PR DESCRIPTION
# Purpose

As the library got updated to support a custom context prop (e.g a shared `ReactReduxContext` with the provider) the type definitions weren't updated. Using typescript an error will be thrown because of the invalid signature. 

This PR adds the optional property and uses the matching type to be compatible again.