### PR TITLE
Fix an invalid type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -61,7 +61,7 @@ declare module 'connected-react-router' {
   export function createMatchSelector<
     S extends RouterRootState, Params extends { [K in keyof Params]?: string }
   >(path: string): matchSelectorFn<S, Params>;
-  export function onLocationChanged(location: Location, action: RouterActionType, isFirstRendering: boolean = false)
+  export function onLocationChanged(location: Location, action: RouterActionType, isFirstRendering: boolean)
     : LocationChangeAction;
 
   export type Push = typeof push;

--- a/index.d.ts
+++ b/index.d.ts
@@ -61,7 +61,7 @@ declare module 'connected-react-router' {
   export function createMatchSelector<
     S extends RouterRootState, Params extends { [K in keyof Params]?: string }
   >(path: string): matchSelectorFn<S, Params>;
-  export function onLocationChanged(location: Location, action: RouterActionType, isFirstRendering: boolean)
+  export function onLocationChanged(location: Location, action: RouterActionType, isFirstRendering?: boolean)
     : LocationChangeAction;
 
   export type Push = typeof push;


### PR DESCRIPTION
First of all, Thank you for maintaining an awesome library project :)

```
Type error: A parameter initializer is only allowed in a function or constructor implementation.  TS2371

    62 |     S extends RouterRootState, Params extends { [K in keyof Params]?: string }
    63 |   >(path: string): matchSelectorFn<S, Params>;
  > 64 |   export function onLocationChanged(location: Location, action: RouterActionType, isFirstRendering: boolean = false)
       |                                                                                   ^
    65 |     : LocationChangeAction;
    66 | 
    67 |   export type Push = typeof push;
```

I've got this type error after bumping up dependency versions.