### PR TITLE
Extend example to illustrate browser back bug

### DIFF
--- a/examples/basic/src/actions/status.js
+++ b/examples/basic/src/actions/status.js
@@ -1,0 +1,4 @@
+export const updateStatus = status => ({
+  type: 'UPDATE STATUS',
+  status
+})

--- a/examples/basic/src/configureStore.js
+++ b/examples/basic/src/configureStore.js
@@ -1,4 +1,5 @@
 import { createBrowserHistory } from 'history'
+import { updateStatus } from './actions/status'
 import { applyMiddleware, compose, createStore } from 'redux'
 import { routerMiddleware } from 'connected-react-router'
 import createRootReducer from './reducers'
@@ -16,6 +17,14 @@ export default function configureStore(preloadedState) {
       ),
     ),
   )
+
+  history.listen((location, action) => {
+    console.log(location, action);
+  });
+
+  history.listen(() => {
+    store.dispatch(updateStatus(200));
+  });
 
   // Hot reloading
   if (module.hot) {

--- a/examples/basic/src/reducers/index.js
+++ b/examples/basic/src/reducers/index.js
@@ -1,8 +1,10 @@
 import { combineReducers } from 'redux'
 import { connectRouter } from 'connected-react-router'
 import counterReducer from './counter'
+import statusReducer from './status'
 
 const rootReducer = (history) => combineReducers({
+  status: statusReducer,
   count: counterReducer,
   router: connectRouter(history)
 })

--- a/examples/basic/src/reducers/status.js
+++ b/examples/basic/src/reducers/status.js
@@ -1,0 +1,10 @@
+const statusReducer = (state = 0, action) => {
+  switch (action.type) {
+    case 'updateStatus':
+      return action.status
+    default:
+      return state
+  }
+}
+
+export default statusReducer


### PR DESCRIPTION
Store updates from history.listen break browser back behavior, causing user to ping-pong between 2 routes.

Steps to reproduce:
1.  User visits `/home` ->`/hello` -> `/counter`
2. On `/counter`, clicks browser back and lands on `/hello`
3. On `/hello` clicks browser back 

Expected behavior: lands on `/home`
Actual behavior: lands on `/counter`

GIF Illustration:
![ping pong](https://user-images.githubusercontent.com/4238041/53143208-fed6c300-3564-11e9-8dd1-6263e7509eda.gif)
