### PR TITLE
Replace uglify option with new minimize options

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,7 +14,7 @@ var config = {
 if (process.env.NODE_ENV === 'production') {
   config.optimization = {
     minimize: true
-  };
+  }
 }
 
-module.exports = config;
+module.exports = config

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,10 +14,9 @@ var config = {
 }
 
 if (process.env.NODE_ENV === 'production') {
-  config.plugins = [
-    new webpack.optimize.UglifyJsPlugin({ sourceMap: true }),
-    new webpack.LoaderOptionsPlugin({ minimize: true })
-  ]
+  config.optimization = {
+    minimize: true
+  };
 }
 
 module.exports = config

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,3 @@
-var webpack = require('webpack')
-
 var config = {
   entry: './src/index',
   module: {
@@ -19,4 +17,4 @@ if (process.env.NODE_ENV === 'production') {
   };
 }
 
-module.exports = config
+module.exports = config;


### PR DESCRIPTION
If I use `eslint-plugin-import` in production, I get this error:

```
ERROR in ./src/javascripts/components/router/index.jsx
Module build failed (from ./node_modules/eslint-loader/index.js):
Error: webpack.optimize.UglifyJsPlugin has been removed, please use config.optimization.minimize instead.
    at Object.get [as UglifyJsPlugin] (/mnt/hot/w/shortcm/frontend/node_modules/webpack/lib/webpack.js:185:10)
    at Object.<anonymous> (/mnt/hot/w/shortcm/frontend/node_modules/connected-react-router/webpack.config.js:18:26)
    at Module._compile (/mnt/hot/w/shortcm/frontend/node_modules/v8-compile-cache/v8-compile-cache.js:178:30)
    at Module._compile (/mnt/hot/w/shortcm/frontend/node_modules/pirates/lib/index.js:83:24)
    at Module._extensions..js (internal/modules/cjs/loader.js:745:10)
    at Object.newLoader [as .js] (/mnt/hot/w/shortcm/frontend/node_modules/pirates/lib/index.js:88:7)
    at Module.load (internal/modules/cjs/loader.js:626:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:566:12)
    at Function.Module._load (internal/modules/cjs/loader.js:558:3)
    at Module.require (internal/modules/cjs/loader.js:663:17)
    at require (/mnt/hot/w/shortcm/frontend/node_modules/v8-compile-cache/v8-compile-cache.js:159:20)
    at Object.exports.resolve (/mnt/hot/w/shortcm/frontend/node_modules/eslint-import-resolver-webpack/index.js:69:27)
    at v2 (/mnt/hot/w/shortcm/frontend/node_modules/eslint-module-utils/resolve.js:94:23)
    at withResolver (/mnt/hot/w/shortcm/frontend/node_modules/eslint-module-utils/resolve.js:99:16)
    at fullResolve (/mnt/hot/w/shortcm/frontend/node_modules/eslint-module-utils/resolve.js:116:22)
    at Function.relative (/mnt/hot/w/shortcm/frontend/node_modules/eslint-module-utils/resolve.js:61:10)
    at relative (/mnt/hot/w/shortcm/frontend/node_modules/eslint-plugin-import/lib/ExportMap.js:359:20)
    at remotePath (/mnt/hot/w/shortcm/frontend/node_modules/eslint-plugin-import/lib/ExportMap.js:388:15)
    at captureDependency (/mnt/hot/w/shortcm/frontend/node_modules/eslint-plugin-import/lib/ExportMap.js:424:7)
    at Array.forEach (<anonymous>)
    at Function.forEach [as parse] (/mnt/hot/w/shortcm/frontend/node_modules/eslint-plugin-import/lib/ExportMap.js:405:12)
    at Function.parse [as for] (/mnt/hot/w/shortcm/frontend/node_modules/eslint-plugin-import/lib/ExportMap.js:310:25)
    at Function.ExportMap.get (/mnt/hot/w/shortcm/frontend/node_modules/eslint-plugin-import/lib/ExportMap.js:273:10)
    at get (/mnt/hot/w/shortcm/frontend/node_modules/eslint-plugin-import/lib/rules/rules/namespace.js:53:35)
    at Array.forEach (<anonymous>)
    at forEach (/mnt/hot/w/shortcm/frontend/node_modules/eslint-plugin-import/lib/rules/rules/namespace.js:82:14)
    at listeners.(anonymous function).forEach.listener (/mnt/hot/w/shortcm/frontend/node_modules/eslint/lib/util/safe-emitter.js:45:58)
    at Array.forEach (<anonymous>)
    at Object.emit (/mnt/hot/w/shortcm/frontend/node_modules/eslint/lib/util/safe-emitter.js:45:38)
    at NodeEventGenerator.applySelector (/mnt/hot/w/shortcm/frontend/node_modules/eslint/lib/util/node-event-generator.js:251:26)
    at NodeEventGenerator.applySelectors (/mnt/hot/w/shortcm/frontend/node_modules/eslint/lib/util/node-event-generator.js:280:22)
    at NodeEventGenerator.enterNode (/mnt/hot/w/shortcm/frontend/node_modules/eslint/lib/util/node-event-generator.js:294:14)
    at CodePathAnalyzer.enterNode (/mnt/hot/w/shortcm/frontend/node_modules/eslint/lib/code-path-analysis/code-path-analyzer.js:632:23)
    at nodeQueue.forEach.traversalInfo (/mnt/hot/w/shortcm/frontend/node_modules/eslint/lib/linter.js:750:28)
    at Array.forEach (<anonymous>)
    at runRules (/mnt/hot/w/shortcm/frontend/node_modules/eslint/lib/linter.js:746:15)
 @ ./src/javascripts/app.js 36:0-29
 @ ./src/javascripts/dynamic_entry.js
 @ multi ./node_modules/@sentry/webpack-plugin/src/sentry-webpack.module.js ./src/javascripts/dynamic_entry.js
```