### PR TITLE
prop-types: declare as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "peerDependencies": {
     "history": "^4.7.2",
+    "prop-types": "^15.0.0 || ^16.0.0",
     "react": "^16.4.0",
     "react-redux": "^6.0.0",
     "react-router": "^4.3.1",


### PR DESCRIPTION
create-react-app when building with yarn, react 16

```
 $ react-scripts start
 Starting the development server...

 Failed to compile.

 /usr/local/share/.cache/yarn/v4/npm-connected-react-router-5.0.1-8379854fad7e027b1e27652c00ad534f8ad244b3/node_modules/connected-react-router/lib/ConnectedRouter.js
 Module not found: Package "connected-react-router@5.0.1" (via "/usr/local/share/.cache/yarn/v4/npm-connected-react-router-5.0.1-8379854fad7e027b1e27652c00ad534f8ad244b3/node_modules/connected-react-router/lib/ConnectedRouter.js") is trying to require the package "prop-types" (via "prop-types") without it being listed in its dependencies (history, react, react-redux, react-router, redux, immutable, seamless-immutable, connected-react-router)
```