### PR TITLE
add isFirstRendering property to RouterState interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -28,7 +28,11 @@ declare module 'connected-react-router' {
 
   export interface LocationChangeAction {
     type: typeof LOCATION_CHANGE;
-    payload: RouterState;
+    payload: LocationChangePayload;
+  }
+
+  export interface LocationChangePayload extends RouterState{
+    isFirstRendering: boolean;
   }
 
   export interface CallHistoryMethodAction<A = any[]> {


### PR DESCRIPTION
The RouterState interface does not have the isFirstRendering property.
This PR is for adding the isFirstRendering property to the RouterState interface.