### PR TITLE
Move prop-types from peerDependencies into dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "immutable": "^3.8.1",
-    "prop-types": "^15.5.7",
+    "prop-types": "^15.7.2",
     "seamless-immutable": "^7.1.3"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -29,11 +29,11 @@
   },
   "dependencies": {
     "immutable": "^3.8.1",
+    "prop-types": "^15.5.7",
     "seamless-immutable": "^7.1.3"
   },
   "peerDependencies": {
     "history": "^4.7.2",
-    "prop-types": "^15.0.0 || ^16.0.0",
     "react": "^16.4.0",
     "react-redux": "^6.0.0",
     "react-router": "^4.3.1",
@@ -61,7 +61,6 @@
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-react": "^7.11.1",
     "jest": "^24.3.1",
-    "prop-types": "^15.5.8",
     "raf": "^3.4.0",
     "react": "^16.4.0",
     "react-dom": "^16.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5526,7 +5526,7 @@ prompts@^2.0.1:
     kleur "^3.0.2"
     sisteransi "^1.0.0"
 
-prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.6.1, prop-types@^15.6.2:
+prop-types@^15.5.7, prop-types@^15.6.1, prop-types@^15.6.2:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
   integrity sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -5534,6 +5534,15 @@ prop-types@^15.5.7, prop-types@^15.6.1, prop-types@^15.6.2:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+prop-types@^15.7.2:
+  version "15.7.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
+  integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.8.1"
+
 prr@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
@@ -5679,6 +5688,11 @@ react-is@^16.3.2, react-is@^16.6.1, react-is@^16.6.3:
   version "16.6.3"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.6.3.tgz#d2d7462fcfcbe6ec0da56ad69047e47e56e7eac0"
   integrity sha512-u7FDWtthB4rWibG/+mFbVd5FvdI20yde86qKGx4lVUTWmPlSWQ4QxbBIrrs+HnXGbxOUlUzTAP/VDmvCwaP2yA==
+
+react-is@^16.8.1:
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
+  integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
 
 react-is@^16.8.4:
   version "16.8.4"


### PR DESCRIPTION
[A recent PR (#265)](https://github.com/supasate/connected-react-router/pull/265) added `prop-types` to `peerDependencies`. I'm afraid that's not quite the right way to do it, because the official `prop-types` documentation states:

> For libraries, we also recommend leaving it in dependencies:

```
  "dependencies": {
    "prop-types": "^15.5.7"
  },
  "peerDependencies": {
    "react": "^15.5.0"
  }
```
-- https://github.com/facebook/prop-types#how-to-depend-on-this-package

I use `connected-react-router` in a Typescript project and don't need `prop-types`, but because it is a `peer-dependency` I receive a "missing peer dependency warning" when installing this package.

This PR therefore removes `prop-types` from both `peerDependencies` and `devDependencies`.

