### PR TITLE
Add a more explicit note on SSR

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ export default function configureStore(preloadedState) {
 
 - Wrap your react-router v4/v5 routing with `ConnectedRouter` and pass the `history` object as a prop.  Remember to delete any usage of `BrowserRouter` or `NativeRouter` as leaving this in will [cause](https://github.com/supasate/connected-react-router/issues/230#issuecomment-461628073) [problems](https://github.com/supasate/connected-react-router/issues/230#issuecomment-476164384) synchronising the state.
 - Place `ConnectedRouter` as a child of `react-redux`'s `Provider`.
+- **N.B.** If doing server-side rendering, you should still use the `StaticRouter` from `react-router` on the server.
 
 ```js
 // index.js


### PR DESCRIPTION
There is already a `How to implement server-side rendering` link to a very nice article. However, we should still be explicit regarding not to use `ConnectedRouter` on server-side.

Indeed, in one of our applications, we happen to be running with  the `ConnectedRouter` on server-side and it was running fine. However, after updating `react-redux` to `7.1` (from `7.0`), the app was starting to break. This was due to the fact that we were using the `context` prop like the `staticContext` prop of `StaticRouter` 😬 Of course, all our logic using the `StaticContext` was also silently breaking ^^