### PR TITLE
Injected query into location

### DIFF
--- a/src/reducer.js
+++ b/src/reducer.js
@@ -5,26 +5,37 @@ import { LOCATION_CHANGE } from './actions'
  * Utilises the search prop of location to construct query.
  */
 const injectQuery = (location) => {
-  if (!location) return location
+  if (!location) {
+    return location
+  }
+
   const searchQuery = location.search || window.location.search
 
   if (typeof searchQuery !== 'string' || searchQuery.length === 0) {
-    return { ...location, query: {} }
+    return {
+      ...location,
+      query: {}
+    }
   }
 
   // Ignore the `?` part of the search string e.g. ?username=codejockie
   const search = searchQuery.substring(1)
-
   // Split the query string on `&` e.g. ?username=codejockie&name=Kennedy
   const queries = search.split('&')
   // Contruct query
   const query = queries.reduce((acc, currentQuery) => {
     // Split on `=`, to get key and value
     const [queryKey, queryValue] = currentQuery.split('=')
-    return { ...acc, [queryKey]: queryValue }
+    return {
+      ...acc,
+      [queryKey]: queryValue
+    }
   }, {})
 
-  return { ...location, query }
+  return {
+    ...location,
+    query
+  }
 }
 
 const createConnectRouter = (structure) => {

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -1,5 +1,32 @@
 import { LOCATION_CHANGE } from './actions'
 
+/**
+ * This function adds the query object to location.
+ * It uses the search field of the location object to build the query object.
+ */
+const injectQuery = (location) => {
+  if (!location) return location
+  const searchQuery = location.search || window.location.search
+
+  if (typeof searchQuery !== 'string' || searchQuery.length === 0) {
+    return { ...location, query: {} }
+  }
+
+  // Ignore the `?` part of the search string e.g. ?username=codejockie
+  const search = searchQuery.substring(1)
+
+  // Split the query string on `&` e.g. ?username=codejockie&name=Kennedy
+  const queries = search.split('&')
+  // Build the query object
+  const query = queries.reduce((acc, currentQuery) => {
+    // Split on `=`, to get the key and value
+    const [queryKey, queryValue] = currentQuery.split('=')
+    return { ...acc, [queryKey]: queryValue }
+  }, {})
+
+  return { ...location, query }
+}
+
 const createConnectRouter = (structure) => {
   const {
     fromJS,
@@ -8,7 +35,7 @@ const createConnectRouter = (structure) => {
 
   const createRouterReducer = (history) => {
     const initialRouterState = fromJS({
-      location: history.location,
+      location: injectQuery(history.location),
       action: history.action,
     })
 
@@ -23,7 +50,7 @@ const createConnectRouter = (structure) => {
         // to prevent the double-rendering issue on initilization
         return isFirstRendering
           ? state
-          : merge(state, { location: fromJS(location), action })
+          : merge(state, { location: fromJS(injectQuery(location)), action })
       }
 
       return state

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -1,8 +1,8 @@
 import { LOCATION_CHANGE } from './actions'
 
 /**
- * This function adds the query object to location.
- * It uses the search field of the location object to build the query object.
+ * Adds query to location.
+ * Utilises the search prop of location to construct query.
  */
 const injectQuery = (location) => {
   if (!location) return location
@@ -17,9 +17,9 @@ const injectQuery = (location) => {
 
   // Split the query string on `&` e.g. ?username=codejockie&name=Kennedy
   const queries = search.split('&')
-  // Build the query object
+  // Contruct query
   const query = queries.reduce((acc, currentQuery) => {
-    // Split on `=`, to get the key and value
+    // Split on `=`, to get key and value
     const [queryKey, queryValue] = currentQuery.split('=')
     return { ...acc, [queryKey]: queryValue }
   }, {})

--- a/test/reducer.test.js
+++ b/test/reducer.test.js
@@ -63,6 +63,7 @@ describe('connectRouter', () => {
             pathname: '/path/to/somewhere',
             search: '?query=test',
             hash: '',
+            query: { query: 'test' }
           },
           action: 'PUSH',
         },
@@ -167,6 +168,7 @@ describe('connectRouter', () => {
             pathname: '/path/to/somewhere',
             search: '?query=test',
             hash: '',
+            query: { query: 'test' }
           },
           action: 'PUSH',
         },
@@ -248,6 +250,7 @@ describe('connectRouter', () => {
             pathname: '/path/to/somewhere',
             search: '?query=test',
             hash: '',
+            query: { query: 'test' }
           },
           action: 'PUSH',
         },

--- a/test/selectors.test.js
+++ b/test/selectors.test.js
@@ -55,7 +55,7 @@ describe("selectors", () => {
 
   describe("getLocation", () => {
     it("gets the location from the state", () => {
-      const location = { pathname: "/", hash: '', search: '' }
+      const location = { pathname: "/", hash: '', query: {}, search: '', }
       store.dispatch(push('/'))
       const state = store.getState()
       expect(getLocation(state)).toEqual(location)


### PR DESCRIPTION
This pull request adds the `query` object to `location`. This is useful when a user needs to access the value(s) in the search/query string without having to parse the search string themself.