### PR TITLE
Don't use window.location when not defined.

### DIFF
--- a/src/reducer.js
+++ b/src/reducer.js
@@ -9,7 +9,7 @@ const injectQuery = (location) => {
     return location
   }
 
-  const searchQuery = location.search || window.location.search
+  const searchQuery = location.search || (window.location && window.location.search)
 
   if (typeof searchQuery !== 'string' || searchQuery.length === 0) {
     return {

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -9,7 +9,7 @@ const injectQuery = (location) => {
     return location
   }
 
-  const searchQuery = location.search || (window.location && window.location.search)
+  const searchQuery = location.search || (window && window.location && window.location.search)
 
   if (typeof searchQuery !== 'string' || searchQuery.length === 0) {
     return {


### PR DESCRIPTION
In server-side-rendering scenarios, `window.location` may be `undefined`, causing this code to crash. As this is only meant as an best-effort override, I think it makes sense to ensure this override only happens when `window.location` is actually present.