### PR TITLE
Move immutable and seamless-immutable to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,16 +28,16 @@
     "posttest": "npm run lint"
   },
   "dependencies": {
-    "immutable": "^3.8.1",
-    "prop-types": "^15.7.2",
-    "seamless-immutable": "^7.1.3"
+    "prop-types": "^15.7.2"
   },
   "peerDependencies": {
+    "immutable": "^3.8.1 || ^4.0.0-rc.1",
     "history": "^4.7.2",
     "react": "^16.4.0",
     "react-redux": "^6.0.0 || ^7.1.0",
     "react-router": "^4.3.1 || ^5.0.0",
-    "redux": "^3.6.0 || ^4.0.0"
+    "redux": "^3.6.0 || ^4.0.0",
+    "seamless-immutable": "^7.1.3"
   },
   "devDependencies": {
     "@babel/cli": "^7.1.5",
@@ -61,6 +61,7 @@
     "eslint": "^5.9.0",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-react": "^7.11.1",
+    "immutable": "^4.0.0-rc.12",
     "jest": "^24.3.1",
     "raf": "^3.4.0",
     "react": "^16.4.0",
@@ -74,6 +75,7 @@
     "redux-mock-store": "^1.2.1",
     "redux-seamless-immutable": "^0.4.0",
     "rewire": "^2.5.2",
+    "seamless-immutable": "^7.1.3",
     "webpack": "^4.41.2",
     "webpack-cli": "^3.3.10"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3657,6 +3657,11 @@ immutable@^3.8.1:
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.2.tgz#c2439951455bb39913daf281376f1530e104adf3"
   integrity sha1-wkOZUUVbs5kT2vKBN28VMOEErfM=
 
+immutable@^4.0.0-rc.12:
+  version "4.0.0-rc.12"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.0.0-rc.12.tgz#ca59a7e4c19ae8d9bf74a97bdf0f6e2f2a5d0217"
+  integrity sha512-0M2XxkZLx/mi3t8NVwIm1g8nHoEmM9p9UBl/G9k4+hm0kBgOVdMV/B3CY5dQ8qG8qc80NN4gDV4HQv6FTJ5q7A==
+
 import-local@2.0.0, import-local@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/import-local/-/import-local-2.0.0.tgz#55070be38a5993cf18ef6db7e961f5bee5c5a09d"
@@ -6507,7 +6512,7 @@ schema-utils@^1.0.0:
     ajv-errors "^1.0.0"
     ajv-keywords "^3.1.0"
 
-seamless-immutable@^7.1.2, seamless-immutable@^7.1.3:
+seamless-immutable@^7.1.2, seamless-immutable@^7.1.4:
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/seamless-immutable/-/seamless-immutable-7.1.4.tgz#6e9536def083ddc4dea0207d722e0e80d0f372f8"
   integrity sha512-XiUO1QP4ki4E2PHegiGAlu6r82o5A+6tRh7IkGGTVg/h+UoeX4nFBeCGPOhb4CYjvkqsfm/TUtvOMYC1xmV30A==


### PR DESCRIPTION
The original discussion: #296

Currently, I use `connected-react-router`, `redux-form` and the project doesn't depend on `immutable` at all. But it seems like `redux-form` is pretty eager for `immutable` library and if it presents inside `node_modules` it will be included in the bundle, which is pretty confusing. I'm not sure what was the purpose to include `immutable` and `seamless-immutable` in the library dependencies (keeping in mind that redux and react-router related stuff lives in `peerDependencies`), so these are breaking changes. Anyway everyone who wants `immutable` or `seamless-immutable` version of this package already has these packages installed, so it won't be a big issue for them to migrate. 