### PR TITLE
Disable query injection when key exists already

### DIFF
--- a/src/reducer.js
+++ b/src/reducer.js
@@ -5,6 +5,11 @@ import { LOCATION_CHANGE } from './actions'
  * Utilises the search prop of location to construct query.
  */
 const injectQuery = (location) => {
+  if (location && location.query) {
+    // Don't inject query if it already exists in history
+    return location
+  }
+
   const searchQuery = location && location.search
 
   if (typeof searchQuery !== 'string' || searchQuery.length === 0) {

--- a/test/reducer.test.js
+++ b/test/reducer.test.js
@@ -123,6 +123,49 @@ describe('connectRouter', () => {
       const nextState = rootReducer(currentState, action)
       expect(nextState).toBe(currentState)
     })
+
+    it('does not replace query if it already exists in location', () => {
+      const mockReducer = (state = {}, action) => {
+        switch (action.type) {
+          default:
+            return state
+        }
+      }
+      const rootReducer = combineReducers({
+        mock: mockReducer,
+        router: connectRouter(mockHistory)
+      })
+
+      const currentState = {
+        mock: {},
+        router: {
+          location: {
+            pathname: '/',
+            search: '',
+            hash: ''
+          },
+          action: 'POP'
+        }
+      }
+      const action = {
+        type: LOCATION_CHANGE,
+        payload: {
+          location: {
+            pathname: '/path/to/somewhere',
+            search: '?query=%7Bvalue%3A%20%27foobar%27%7D',
+            hash: '',
+            query: { query: { value: 'foobar' } }
+          },
+          action: 'PUSH'
+        }
+      }
+      const nextState = rootReducer(currentState, action)
+      const expectedState = {
+        mock: {},
+        router: action.payload
+      }
+      expect(nextState).toEqual(expectedState)
+    })
   })
 
   describe('with immutable structure', () => {


### PR DESCRIPTION
When using ConnectedRouter you may have already set a query with a custom parser like this

```jsx
const history = qhistory(createBrowserHistory(), stringify, parseQueryString);

<ConnectedRouter history={history}>
```

This PR ensures it doesn't override existing queries which may have different parsing logic

Ive published this under https://www.npmjs.com/package/@dr3/connected-react-router for the meantime :) 