### PR TITLE
Make initial location POP optional

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -353,3 +353,15 @@ ReactDOM.render(
   </Provider>
 )
 ```
+
+### How to stop initial location change
+In order to make this package more compatible with react-router-redux, a LOCATION_CHANGE action is dispatched for the initial location. This can however be disabled via the `noInitialPop` prop.
+```js
+ReactDOM.render(
+  <Provider store={store}>
+    <ConnectedRouter history={history} noInitialPop>
+      <Route path="/" component={myComponent} exact={true} />
+    </ConnectedRouter>
+  </Provider>
+)
+```

--- a/index.d.ts
+++ b/index.d.ts
@@ -17,6 +17,7 @@ declare module 'connected-react-router' {
   interface ConnectedRouterProps<S = LocationState> {
     history: History<S>;
     context?: React.Context<ReactReduxContextValue>;
+    noInitialPop?: boolean;
   }
 
   export type RouterActionType = Action;

--- a/src/ConnectedRouter.js
+++ b/src/ConnectedRouter.js
@@ -69,10 +69,13 @@ const createConnectedRouter = (structure) => {
 
       // Listen to history changes
       this.unlisten = history.listen(handleLocationChange)
-      // Dispatch a location change action for the initial location.
-      // This makes it backward-compatible with react-router-redux.
-      // But, we add `isFirstRendering` to `true` to prevent double-rendering.
-      handleLocationChange(history.location, history.action, true)
+    
+      if (!props.noInitialPop) {
+        // Dispatch a location change action for the initial location.
+        // This makes it backward-compatible with react-router-redux.
+        // But, we add `isFirstRendering` to `true` to prevent double-rendering.
+        handleLocationChange(history.location, history.action, true)
+      }
     }
 
     componentWillUnmount() {
@@ -105,6 +108,7 @@ const createConnectedRouter = (structure) => {
     basename: PropTypes.string,
     children: PropTypes.oneOfType([ PropTypes.func, PropTypes.node ]),
     onLocationChanged: PropTypes.func.isRequired,
+    noInitialPop: PropTypes.bool,
   }
 
   const mapDispatchToProps = dispatch => ({

--- a/test/ConnectedRouter.test.js
+++ b/test/ConnectedRouter.test.js
@@ -191,6 +191,18 @@ describe('ConnectedRouter', () => {
       history.push('/new-location')
       expect(renderCount).toBe(2)
     })
+
+    it('does not call `props.onLocationChanged()` on intial location when `noInitialPop` prop is passed ', () => {
+      mount(
+        <Provider store={store}>
+          <ConnectedRouter {...props} noInitialPop>
+            <Route path="/" render={() => <div>Home</div>} />
+          </ConnectedRouter>
+        </Provider>
+      )
+
+      expect(onLocationChangedSpy.mock.calls).toHaveLength(0)
+    })
   })
 
   describe('with immutable structure', () => {


### PR DESCRIPTION
Makes the logic added back in https://github.com/supasate/connected-react-router/pull/172/files optional

Can be called like
```jsx
<ConnectedRouter history={history} noInitialPop>
```

Discussed in https://github.com/supasate/connected-react-router/issues/144