### PR TITLE
Fix location state (#394)

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,9 @@
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {
-    "immutable": "^3.8.1 || ^4.0.0-rc.1",
     "history": "^4.7.2",
+    "immutable": "^3.8.1 || ^4.0.0-rc.1",
+    "lodash.isequalwith": "^4.4.0",
     "react": "^16.4.0",
     "react-redux": "^6.0.0 || ^7.1.0",
     "react-router": "^4.3.1 || ^5.0.0",

--- a/src/ConnectedRouter.js
+++ b/src/ConnectedRouter.js
@@ -2,7 +2,7 @@ import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import { connect, ReactReduxContext } from 'react-redux'
 import { Router } from 'react-router'
-import { isEqual } from 'lodash'
+import isEqualWith from 'lodash.isequalwith'
 import { onLocationChanged } from './actions'
 import createSelectors from './selectors'
 
@@ -19,7 +19,7 @@ const createConnectedRouter = (structure) => {
     constructor(props) {
       super(props)
 
-      const { store, history, onLocationChanged } = props
+      const { store, history, onLocationChanged, stateCompareFunction} = props
 
       this.inTimeTravelling = false
 
@@ -38,7 +38,7 @@ const createConnectedRouter = (structure) => {
           search: searchInHistory,
           hash: hashInHistory,
           state: stateInHistory,
-        } = history.location
+				} = history.location
 
         // If we do time travelling, the location in store is changed but location in history is not changed
         if (
@@ -46,7 +46,7 @@ const createConnectedRouter = (structure) => {
           (pathnameInHistory !== pathnameInStore ||
             searchInHistory !== searchInStore ||
             hashInHistory !== hashInStore ||
-            !isEqual(stateInStore, stateInHistory))
+            !isEqualWith(stateInStore, stateInHistory, stateCompareFunction))
         ) {
           this.inTimeTravelling = true
           // Update history's location to match store's location
@@ -109,7 +109,8 @@ const createConnectedRouter = (structure) => {
     basename: PropTypes.string,
     children: PropTypes.oneOfType([ PropTypes.func, PropTypes.node ]),
     onLocationChanged: PropTypes.func.isRequired,
-    noInitialPop: PropTypes.bool,
+		noInitialPop: PropTypes.bool,
+    stateCompareFunction: PropTypes.func,
   }
 
   const mapDispatchToProps = dispatch => ({

--- a/src/ConnectedRouter.js
+++ b/src/ConnectedRouter.js
@@ -109,10 +109,7 @@ const createConnectedRouter = (structure) => {
     basename: PropTypes.string,
     children: PropTypes.oneOfType([ PropTypes.func, PropTypes.node ]),
     onLocationChanged: PropTypes.func.isRequired,
-<<<<<<< HEAD
-		noInitialPop: PropTypes.bool,
-=======
->>>>>>> Split store update test into two + updated custom state compare function test + spacing
+    noInitialPop: PropTypes.bool,
     stateCompareFunction: PropTypes.func,
   }
 

--- a/src/ConnectedRouter.js
+++ b/src/ConnectedRouter.js
@@ -19,7 +19,7 @@ const createConnectedRouter = (structure) => {
     constructor(props) {
       super(props)
 
-      const { store, history, onLocationChanged, stateCompareFunction} = props
+      const { store, history, onLocationChanged, stateCompareFunction } = props
 
       this.inTimeTravelling = false
 
@@ -38,7 +38,7 @@ const createConnectedRouter = (structure) => {
           search: searchInHistory,
           hash: hashInHistory,
           state: stateInHistory,
-				} = history.location
+        } = history.location
 
         // If we do time travelling, the location in store is changed but location in history is not changed
         if (
@@ -109,7 +109,10 @@ const createConnectedRouter = (structure) => {
     basename: PropTypes.string,
     children: PropTypes.oneOfType([ PropTypes.func, PropTypes.node ]),
     onLocationChanged: PropTypes.func.isRequired,
+<<<<<<< HEAD
 		noInitialPop: PropTypes.bool,
+=======
+>>>>>>> Split store update test into two + updated custom state compare function test + spacing
     stateCompareFunction: PropTypes.func,
   }
 

--- a/src/ConnectedRouter.js
+++ b/src/ConnectedRouter.js
@@ -2,6 +2,7 @@ import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import { connect, ReactReduxContext } from 'react-redux'
 import { Router } from 'react-router'
+import { isEqual } from 'lodash'
 import { onLocationChanged } from './actions'
 import createSelectors from './selectors'
 
@@ -45,7 +46,7 @@ const createConnectedRouter = (structure) => {
           (pathnameInHistory !== pathnameInStore ||
             searchInHistory !== searchInStore ||
             hashInHistory !== hashInStore ||
-            stateInStore !== stateInHistory)
+            !isEqual(stateInStore, stateInHistory))
         ) {
           this.inTimeTravelling = true
           // Update history's location to match store's location

--- a/test/ConnectedRouter.test.js
+++ b/test/ConnectedRouter.test.js
@@ -166,7 +166,9 @@ describe('ConnectedRouter', () => {
           },
           action: 'PUSH',
         }
-      })
+			})
+			
+			expect(props.history.entries).toHaveLength(3)
 
       store.dispatch({
         type: LOCATION_CHANGE,
@@ -179,8 +181,10 @@ describe('ConnectedRouter', () => {
           },
           action: 'PUSH',
         }
-      })
-
+			})
+			
+			expect(props.history.entries).toHaveLength(3)
+			
       store.dispatch({
         type: LOCATION_CHANGE,
         payload: {
@@ -208,8 +212,11 @@ describe('ConnectedRouter', () => {
       mount(
         <Provider store={store}>
           <ConnectedRouter
-            stateCompareFunction={() => true}
-            {...props} >
+            stateCompareFunction={(a, b) => {
+							return a === undefined  || (a.foo === "baz" && b.foo === 'bar') ? true : false
+            }}
+            {...props}
+					>
             <Route path="/" render={() => <div>Home</div>} />
           </ConnectedRouter>
         </Provider>
@@ -229,7 +236,9 @@ describe('ConnectedRouter', () => {
           },
           action: 'PUSH',
         }
-      })
+			})
+			
+      expect(props.history.entries).toHaveLength(3)
 
       store.dispatch({
         type: LOCATION_CHANGE,
@@ -244,7 +253,7 @@ describe('ConnectedRouter', () => {
         }
       })
 
-      expect(props.history.entries).toHaveLength(2)
+      expect(props.history.entries).toHaveLength(3)
     })
 
     it('only renders one time when mounted', () => {

--- a/test/ConnectedRouter.test.js
+++ b/test/ConnectedRouter.test.js
@@ -9,7 +9,7 @@ import { createMemoryHistory } from 'history'
 import { Route } from 'react-router'
 import { Provider } from 'react-redux'
 import createConnectedRouter from '../src/ConnectedRouter'
-import { onLocationChanged } from '../src/actions'
+import { onLocationChanged, LOCATION_CHANGE } from '../src/actions'
 import plainStructure from '../src/structure/plain'
 import immutableStructure from '../src/structure/immutable'
 import seamlessImmutableStructure from '../src/structure/seamless-immutable'
@@ -134,6 +134,117 @@ describe('ConnectedRouter', () => {
       props.history.push({ pathname: '/new-location', state: { foo: 'bar' } })
 
       expect(onLocationChangedSpy.mock.calls[1][0].state).toEqual({ foo: 'bar'})
+		})
+		
+		it('changing store location updates history', () => {
+			store = createStore(
+        combineReducers({
+					router: connectRouter(props.history)
+        }),
+        compose(applyMiddleware(routerMiddleware(props.history)))
+			)
+			
+      mount(
+        <Provider store={store}>
+					<ConnectedRouter {...props}>
+            <Route path="/" render={() => <div>Home</div>} />
+          </ConnectedRouter>
+        </Provider>
+			)
+
+			// Need to add PUSH action to history because initial POP action prevents history updates
+			props.history.push({ pathname: "/" })
+
+			store.dispatch({
+				type: LOCATION_CHANGE,
+        payload: {
+          location: {
+            pathname: '/',
+            search: '',
+						hash: '',
+						state: {foo: 'bar'}
+          },
+          action: 'PUSH',
+        }
+			})
+
+			store.dispatch({
+				type: LOCATION_CHANGE,
+        payload: {
+          location: {
+            pathname: '/',
+            search: '',
+						hash: '',
+						state: {foo: 'bar'}
+          },
+          action: 'PUSH',
+        }
+			})
+
+			store.dispatch({
+				type: LOCATION_CHANGE,
+        payload: {
+          location: {
+            pathname: '/',
+            search: '',
+						hash: '',
+						state: {foo: 'baz'}
+          },
+          action: 'PUSH',
+        }
+			})
+
+			expect(props.history.entries).toHaveLength(4)
+		})
+		
+		it('supports custom state compare function', () => {
+			store = createStore(
+        combineReducers({
+					router: connectRouter(props.history)
+        }),
+        compose(applyMiddleware(routerMiddleware(props.history)))
+			)
+			
+      mount(
+        <Provider store={store}>
+					<ConnectedRouter
+						stateCompareFunction={() => true}
+						{...props} >
+            <Route path="/" render={() => <div>Home</div>} />
+          </ConnectedRouter>
+        </Provider>
+			)
+
+			// Need to add PUSH action to history because initial POP action prevents history updates
+			props.history.push({ pathname: "/" })
+
+			store.dispatch({
+				type: LOCATION_CHANGE,
+        payload: {
+          location: {
+            pathname: '/',
+            search: '',
+						hash: '',
+						state: {foo: 'bar'}
+          },
+          action: 'PUSH',
+        }
+			})
+
+			store.dispatch({
+				type: LOCATION_CHANGE,
+        payload: {
+          location: {
+            pathname: '/',
+            search: '',
+						hash: '',
+						state: {foo: 'baz'}
+          },
+          action: 'PUSH',
+        }
+			})
+
+			expect(props.history.entries).toHaveLength(2)
     })
 
     it('only renders one time when mounted', () => {

--- a/test/ConnectedRouter.test.js
+++ b/test/ConnectedRouter.test.js
@@ -134,117 +134,117 @@ describe('ConnectedRouter', () => {
       props.history.push({ pathname: '/new-location', state: { foo: 'bar' } })
 
       expect(onLocationChangedSpy.mock.calls[1][0].state).toEqual({ foo: 'bar'})
-		})
-		
-		it('changing store location updates history', () => {
-			store = createStore(
+    })
+    
+    it('changing store location updates history', () => {
+      store = createStore(
         combineReducers({
-					router: connectRouter(props.history)
+          router: connectRouter(props.history)
         }),
         compose(applyMiddleware(routerMiddleware(props.history)))
-			)
-			
+      )
+      
       mount(
         <Provider store={store}>
-					<ConnectedRouter {...props}>
+          <ConnectedRouter {...props}>
             <Route path="/" render={() => <div>Home</div>} />
           </ConnectedRouter>
         </Provider>
-			)
+      )
 
-			// Need to add PUSH action to history because initial POP action prevents history updates
-			props.history.push({ pathname: "/" })
+      // Need to add PUSH action to history because initial POP action prevents history updates
+      props.history.push({ pathname: "/" })
 
-			store.dispatch({
-				type: LOCATION_CHANGE,
+      store.dispatch({
+        type: LOCATION_CHANGE,
         payload: {
           location: {
             pathname: '/',
             search: '',
-						hash: '',
-						state: {foo: 'bar'}
+            hash: '',
+            state: { foo: 'bar' }
           },
           action: 'PUSH',
         }
-			})
+      })
 
-			store.dispatch({
-				type: LOCATION_CHANGE,
+      store.dispatch({
+        type: LOCATION_CHANGE,
         payload: {
           location: {
             pathname: '/',
             search: '',
-						hash: '',
-						state: {foo: 'bar'}
+            hash: '',
+            state: { foo: 'bar' }
           },
           action: 'PUSH',
         }
-			})
+      })
 
-			store.dispatch({
-				type: LOCATION_CHANGE,
+      store.dispatch({
+        type: LOCATION_CHANGE,
         payload: {
           location: {
             pathname: '/',
             search: '',
-						hash: '',
-						state: {foo: 'baz'}
+            hash: '',
+            state: { foo: 'baz' }
           },
           action: 'PUSH',
         }
-			})
+      })
 
-			expect(props.history.entries).toHaveLength(4)
-		})
-		
-		it('supports custom state compare function', () => {
-			store = createStore(
+      expect(props.history.entries).toHaveLength(4)
+    })
+    
+    it('supports custom state compare function', () => {
+      store = createStore(
         combineReducers({
-					router: connectRouter(props.history)
+          router: connectRouter(props.history)
         }),
         compose(applyMiddleware(routerMiddleware(props.history)))
-			)
-			
+      )
+      
       mount(
         <Provider store={store}>
-					<ConnectedRouter
-						stateCompareFunction={() => true}
-						{...props} >
+          <ConnectedRouter
+            stateCompareFunction={() => true}
+            {...props} >
             <Route path="/" render={() => <div>Home</div>} />
           </ConnectedRouter>
         </Provider>
-			)
+      )
 
-			// Need to add PUSH action to history because initial POP action prevents history updates
-			props.history.push({ pathname: "/" })
+      // Need to add PUSH action to history because initial POP action prevents history updates
+      props.history.push({ pathname: "/" })
 
-			store.dispatch({
-				type: LOCATION_CHANGE,
+      store.dispatch({
+        type: LOCATION_CHANGE,
         payload: {
           location: {
             pathname: '/',
             search: '',
-						hash: '',
-						state: {foo: 'bar'}
+            hash: '',
+            state: { foo: 'bar' }
           },
           action: 'PUSH',
         }
-			})
+      })
 
-			store.dispatch({
-				type: LOCATION_CHANGE,
+      store.dispatch({
+        type: LOCATION_CHANGE,
         payload: {
           location: {
             pathname: '/',
             search: '',
-						hash: '',
-						state: {foo: 'baz'}
+            hash: '',
+            state: { foo: 'baz' }
           },
           action: 'PUSH',
         }
-			})
+      })
 
-			expect(props.history.entries).toHaveLength(2)
+      expect(props.history.entries).toHaveLength(2)
     })
 
     it('only renders one time when mounted', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4733,6 +4733,11 @@ lodash.flattendeep@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
   integrity sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=
 
+lodash.isequalwith@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequalwith/-/lodash.isequalwith-4.4.0.tgz#266726ddd528f854f21f4ea98a065606e0fbc6b0"
+  integrity sha1-Jmcm3dUo+FTyH06pigZWBuD7xrA=
+
 lodash.isplainobject@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"


### PR DESCRIPTION
Closes #394. This change deep compares location state objects to prevent incorrectly pushing to history multiple times when state is changed.

- [x] Ran all tests