### PR TITLE
Fixing mismatch types for Redux store context

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -16,7 +16,7 @@ declare module 'connected-react-router' {
 
   interface ConnectedRouterProps<S = LocationState> {
     history: History<S>;
-    context?: React.Context<ReactReduxContextValue>;
+    context?: React.Context<ReactReduxContextValue> | React.Context<{ store: any }>;
   }
 
   export type RouterActionType = Action;


### PR DESCRIPTION
`Type 'Context<{ store: Store<any, Action<any>> & { dispatch: any; }; }>' is not assignable to type 'Context<ReactReduxContextValue<any, AnyAction>>'. The types of 'Provider.propTypes' are incompatible between these types.`