### PR TITLE
Add "omitRouter" option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -18,6 +18,7 @@ declare module 'connected-react-router' {
     history: History<S>;
     context?: React.Context<ReactReduxContextValue>;
     noInitialPop?: boolean;
+    omitRouter?: boolean;
   }
 
   export type RouterActionType = Action;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "connected-react-router",
-  "version": "6.8.0",
+  "version": "6.8.1",
   "description": "A Redux binding for React Router v4 and v5",
   "main": "lib/index.js",
   "module": "esm/index.js",

--- a/src/ConnectedRouter.js
+++ b/src/ConnectedRouter.js
@@ -85,7 +85,11 @@ const createConnectedRouter = (structure) => {
     }
 
     render() {
-      const { history, children } = this.props
+      const { omitRouter, history, children } = this.props
+
+      if (omitRouter) {
+        return <>{ children }</>
+      }
 
       return (
         <Router history={history}>
@@ -111,6 +115,7 @@ const createConnectedRouter = (structure) => {
     onLocationChanged: PropTypes.func.isRequired,
     noInitialPop: PropTypes.bool,
     stateCompareFunction: PropTypes.func,
+    omitRouter: PropTypes.bool,
   }
 
   const mapDispatchToProps = dispatch => ({

--- a/src/ConnectedRouter.js
+++ b/src/ConnectedRouter.js
@@ -86,6 +86,10 @@ const createConnectedRouter = (structure) => {
 
     render() {
       const { omitRouter, history, children } = this.props
+      
+      // The `omitRouter` option is available for applications that must
+      // have a Router instance higher in the component tree but still desire
+      // to use connected-react-router for its Redux integration.
 
       if (omitRouter) {
         return <>{ children }</>


### PR DESCRIPTION
This allows for the following configuration:

<img width="562" alt="Screen Shot 2020-05-18 at 1 35 35 PM" src="https://user-images.githubusercontent.com/10765285/82257219-81873300-990c-11ea-8903-a98882ae9157.png">

Currently, my team is running into this situation where `Router` is provided at a higher point in the architecture and we want to use `connected-react-router` with our Redux store, but we need `connected-react-router` to use the `Router` instance that is higher up the tree instead of providing its own.

This option is added as opt-in only and should not affect any existing usage.