### PR TITLE
Fix: Export getRouter() selector

### DIFF
--- a/src/immutable.js
+++ b/src/immutable.js
@@ -8,4 +8,4 @@ export { default as routerMiddleware } from "./middleware"
 
 export const ConnectedRouter = /*#__PURE__*/ createConnectedRouter(immutableStructure)
 export const connectRouter = /*#__PURE__*/ createConnectRouter(immutableStructure)
-export const { getLocation, getAction, getHash, getSearch, createMatchSelector } = /*#__PURE__*/ createSelectors(immutableStructure)
+export const { getLocation, getAction, getHash, getRouter, getSearch, createMatchSelector } = /*#__PURE__*/ createSelectors(immutableStructure)

--- a/src/index.js
+++ b/src/index.js
@@ -8,4 +8,4 @@ export { default as routerMiddleware } from "./middleware"
 
 export const ConnectedRouter = /*#__PURE__*/ createConnectedRouter(plainStructure)
 export const connectRouter = /*#__PURE__*/ createConnectRouter(plainStructure)
-export const { getLocation, getAction, getHash, getSearch, createMatchSelector } = /*#__PURE__*/ createSelectors(plainStructure)
+export const { getLocation, getAction, getHash, getRouter, getSearch, createMatchSelector } = /*#__PURE__*/ createSelectors(plainStructure)

--- a/src/seamless-immutable.js
+++ b/src/seamless-immutable.js
@@ -8,4 +8,4 @@ export { default as routerMiddleware } from "./middleware"
 
 export const ConnectedRouter = /*#__PURE__*/ createConnectedRouter(immutableStructure)
 export const connectRouter = /*#__PURE__*/ createConnectRouter(immutableStructure)
-export const { getLocation, getAction, getHash, getSearch, createMatchSelector } = /*#__PURE__*/ createSelectors(immutableStructure)
+export const { getLocation, getAction, getHash, getRouter, getSearch, createMatchSelector } = /*#__PURE__*/ createSelectors(immutableStructure)


### PR DESCRIPTION
Fixes #427:

The types file lists `getRouter()` as being available:

https://github.com/supasate/connected-react-router/blob/f27512640e992f420935c7790cdbed746a8306e0/index.d.ts#L68

It's returned from `createSelectors()`:

https://github.com/supasate/connected-react-router/blob/adc65f8d55dfde0f4db7609c72c723ce62698917/src/selectors.js#L49-L56

but is not actually exported from the package:

https://github.com/supasate/connected-react-router/blob/e444615c281bcb4d518636bee2666d1e9357bf8e/src/index.js#L11

https://github.com/supasate/connected-react-router/blob/e444615c281bcb4d518636bee2666d1e9357bf8e/src/immutable.js#L11

https://github.com/supasate/connected-react-router/blob/e444615c281bcb4d518636bee2666d1e9357bf8e/src/seamless-immutable.js#L11

This PR rectifies this by adding `getRouter` to the export in each of the 3 files above.