### PR TITLE
react-redux dependency now is optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,12 +34,12 @@
     "history": "^4.7.2",
     "lodash.isequalwith": "^4.4.0",
     "react": "^16.4.0",
-    "react-redux": "^6.0.0 || ^7.1.0",
     "react-router": "^4.3.1 || ^5.0.0",
     "redux": "^3.6.0 || ^4.0.0"
   },
   "optionalDependencies": {
     "immutable": "^3.8.1 || ^4.0.0-rc.1",
+    "react-redux": "^6.0.0 || ^7.1.0",
     "seamless-immutable": "^7.1.3"
   },
   "devDependencies": {

--- a/src/ConnectedRouter.js
+++ b/src/ConnectedRouter.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
-import { connect, ReactReduxContext } from 'react-redux'
+import { ReactReduxContext } from 'react-redux'
 import { Router } from 'react-router'
 import isEqualWith from 'lodash.isequalwith'
 import { onLocationChanged } from './actions'
@@ -19,7 +19,7 @@ const createConnectedRouter = (structure) => {
     constructor(props) {
       super(props)
 
-      const { store, history, onLocationChanged, stateCompareFunction } = props
+      const { store, history, stateCompareFunction } = props
 
       this.inTimeTravelling = false
 
@@ -60,9 +60,11 @@ const createConnectedRouter = (structure) => {
       })
 
       const handleLocationChange = (location, action, isFirstRendering = false) => {
+        const { store } = props
+
         // Dispatch onLocationChanged except when we're in time travelling
         if (!this.inTimeTravelling) {
-          onLocationChanged(location, action, isFirstRendering)
+          store.dispatch(onLocationChanged(location, action, isFirstRendering))
         } else {
           this.inTimeTravelling = false
         }
@@ -107,6 +109,7 @@ const createConnectedRouter = (structure) => {
     store: PropTypes.shape({
       getState: PropTypes.func.isRequired,
       subscribe: PropTypes.func.isRequired,
+      dispatch: PropTypes.func.isRequired,
     }).isRequired,
     history: PropTypes.shape({
       action: PropTypes.string.isRequired,
@@ -114,23 +117,17 @@ const createConnectedRouter = (structure) => {
       location: PropTypes.object.isRequired,
       push: PropTypes.func.isRequired,
     }).isRequired,
-    basename: PropTypes.string,
     children: PropTypes.oneOfType([ PropTypes.func, PropTypes.node ]),
-    onLocationChanged: PropTypes.func.isRequired,
     noInitialPop: PropTypes.bool,
     stateCompareFunction: PropTypes.func,
     omitRouter: PropTypes.bool,
   }
 
-  const mapDispatchToProps = dispatch => ({
-    onLocationChanged: (location, action, isFirstRendering) => dispatch(onLocationChanged(location, action, isFirstRendering))
-  })
-
   const ConnectedRouterWithContext = props => {
     const Context = props.context || ReactReduxContext
 
     if (Context == null) {
-      throw 'Please upgrade to react-redux v6'
+      throw 'Please install react-redux v6 or higher'
     }
 
     return (
@@ -144,7 +141,7 @@ const createConnectedRouter = (structure) => {
     context: PropTypes.object,
   }
 
-  return connect(null, mapDispatchToProps)(ConnectedRouterWithContext)
+  return ConnectedRouterWithContext
 }
 
 export default createConnectedRouter


### PR DESCRIPTION
#### Use case
If I use custom `context` prop in `ConnectedRouter` component, I want to be able not to use `react-redux` library at all.

#### Changes
I have changed usage of `react-redux` library. Code have became simplier a little bit and dependency from `react-redux` library is not so strict now. 