### PR TITLE
fix history listener

### DIFF
--- a/src/ConnectedRouter.js
+++ b/src/ConnectedRouter.js
@@ -59,10 +59,10 @@ const createConnectedRouter = (structure) => {
         }
       })
 
-      const handleLocationChange = (location, action, isFirstRendering = false) => {
+      const handleLocationChange = ({location, action}, isFirstRendering = false) => {
         // Dispatch onLocationChanged except when we're in time travelling
         if (!this.inTimeTravelling) {
-          onLocationChanged(location, action, isFirstRendering)
+          onLocationChanged({location, action}, isFirstRendering)
         } else {
           this.inTimeTravelling = false
         }
@@ -75,7 +75,7 @@ const createConnectedRouter = (structure) => {
         // Dispatch a location change action for the initial location.
         // This makes it backward-compatible with react-router-redux.
         // But, we add `isFirstRendering` to `true` to prevent double-rendering.
-        handleLocationChange(history.location, history.action, true)
+        handleLocationChange({location, action} = history, true)
       }
     }
 
@@ -123,7 +123,7 @@ const createConnectedRouter = (structure) => {
   }
 
   const mapDispatchToProps = dispatch => ({
-    onLocationChanged: (location, action, isFirstRendering) => dispatch(onLocationChanged(location, action, isFirstRendering))
+    onLocationChanged: ({location, action}, isFirstRendering) => dispatch(onLocationChanged({location, action}, isFirstRendering))
   })
 
   const ConnectedRouterWithContext = props => {

--- a/src/actions.js
+++ b/src/actions.js
@@ -4,7 +4,7 @@
  */
 export const LOCATION_CHANGE = '@@router/LOCATION_CHANGE'
 
-export const onLocationChanged = (location, action, isFirstRendering = false) => ({
+export const onLocationChanged = ({location, action}, isFirstRendering = false) => ({
   type: LOCATION_CHANGE,
   payload: {
     location,


### PR DESCRIPTION
Hi amazing library

can't wait to use it (uni flow and store trust-worthiness)

however whenever I changed location my app crashed mentioning it could not find the router reducer. after some debugging I found the actions payload was malformed
it had no history action and its location was an object of the values for action and location.

looking over at the history.js project, it expects its listeners to take an object which includes location and action properties, your listener expects these values to be their own parameters.