### PR TITLE
Add compatibility with React 17 and npm 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "peerDependencies": {
     "history": "^4.7.2",
     "lodash.isequalwith": "^4.4.0",
-    "react": "^16.4.0 || ^ 17.0.0",
+    "react": "^16.4.0 || ^17.0.0",
     "react-redux": "^6.0.0 || ^7.1.0",
     "react-router": "^4.3.1 || ^5.0.0",
     "redux": "^3.6.0 || ^4.0.0"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "peerDependencies": {
     "history": "^4.7.2",
     "lodash.isequalwith": "^4.4.0",
-    "react": "^16.4.0",
+    "react": "^16.4.0 || ^ 17.0.0",
     "react-redux": "^6.0.0 || ^7.1.0",
     "react-router": "^4.3.1 || ^5.0.0",
     "redux": "^3.6.0 || ^4.0.0"


### PR DESCRIPTION
React 17 was published in october 2020 (https://github.com/facebook/react/blob/master/CHANGELOG.md#1700-october-20-2020).

npm 7 was published in october 2020 (https://github.blog/2020-10-13-presenting-v7-0-0-of-the-npm-cli/) and is bundled by default with node 15.

npm 7 changes the way peer dependencies are handled. As a consequence, `connected-react-router` doesn't work with react 17, because the `peerDependency` on React is on `^16.4.0`. As a consequence, all packages depending on `connected-react-router` and React 17 cannot be installed with npm 7 (e.g. https://github.com/marmelab/react-admin/issues/5908)

I know this is not your repo's fault, and that npm shouldn't have broken BC, but the simple change I propose is an easy fix. So please consider merging it and releasing a new version.

Thanks in advance!

