### PR TITLE
fix query type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -27,7 +27,7 @@ declare module 'connected-react-router' {
   export type RouterActionType = Action;
 
   export interface RouterLocation<S> extends Location<S> {
-    query: Record<string, string>
+    query: Partial<Record<string, string>>
   }
 
   export interface RouterState<S = LocationState> {


### PR DESCRIPTION
query parameters may be missing;
query is an empty object by default [1](https://github.com/supasate/connected-react-router/blob/master/src/reducer.js#L18) [2](https://github.com/supasate/connected-react-router/blob/master/src/reducer.js#L34)
And this is a fix for the [discussion](https://github.com/supasate/connected-react-router/issues/472#issuecomment-833655183)