### PR TITLE
add children to typings to support removal of same in react 18 typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -22,6 +22,7 @@ declare module 'connected-react-router' {
     noInitialPop?: boolean;
     noTimeTravelDebugging?: boolean;
     omitRouter?: boolean;
+    children?: React.ReactNode;
   }
 
   export type RouterActionType = Action;


### PR DESCRIPTION
Current typing definition will cause the following error when upgrading to React 18 typing definitions
Property 'children' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes ...

This PR adds the children prop.

Ref: https://github.com/supasate/connected-react-router/issues/565

See also SO answer as reference:
https://stackoverflow.com/questions/71788254/react-18-typescript-children-fc/71809927#71809927